### PR TITLE
To allow PRs from forks, use pull_request_target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@
 name: PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
As per: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
this should allow PRs from forks to still deploy test websites.
It means that PRs of the infrastructure itself won't get tested as part of the PR though.