### PR TITLE
Revert "To allow PRs from forks, use pull_request_target"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@
 name: PR
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
This reverts commit 92006f2b46a6d82269672b9911c77d4c90ff2f07.

This is not what we wanted - it does not run the actions on the code
from the PR itself, meaning its previews (for example) are not useful

We still have the issue of GitHub secrets not being shared with forks, which prevents the deploy step :thinking: 

I think the intermediate solution is that PRs should be branches for now, until we work something out.