### PR TITLE
link-checker: avoid root warning

### DIFF
--- a/docker/linkchecker.sh
+++ b/docker/linkchecker.sh
@@ -19,6 +19,7 @@ mkdir -p "$OUTPUT_DIR"
 chmod go+rwx "$OUTPUT_DIR"
 
 linkchecker \
+    --allow-root \
     --no-status \
     --ignore-url="print$" \
     --ignore-url="/blob/" \


### PR DESCRIPTION
The warning confuses the follow-on output check for the link checker.

