### PR TITLE
github workflows: remove deprecated set-env

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
           MSG="${MSG//'%'/'%25'}"
           MSG="${MSG//$'\n'/'%0A'}"
           MSG="${MSG//$'\r'/'%0D'}"
-          echo "::set-env name=MSG::$MSG"
+          echo "MSG=$MSG" >> $GITHUB_ENV
       - name: Print message
         run: |
           echo "$MSG"


### PR DESCRIPTION
See also
https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w

and

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files