### PR TITLE
Ignore .well-known directory so certbot can work

### DIFF
--- a/content/.ignore
+++ b/content/.ignore
@@ -7,3 +7,4 @@ js
 linklint
 validator
 Verification
+.well-known


### PR DESCRIPTION
certbot creates a directory .well-known and puts stuff in it.
git should ignore that (ephemeral) stuff, and indeed, the entire directory.
Adding the directory to .ignore means it won't ever be committed by mistake.

Signed-off-by: Peter Chubb <Peter.Chubb@data61.csiro.au>