### PR TITLE
ignore ETH link

### DIFF
--- a/docker/linkchecker.sh
+++ b/docker/linkchecker.sh
@@ -24,6 +24,7 @@ linkchecker \
     --ignore-url="/blob/" \
     --ignore-url="/About/Performance" \
     --ignore-url="/lists/" \
+    --ignore-url="https://ethz.ch/en.html" \
     --check-extern \
     --output html \
     "$OUTPUT_SNAPSHOT_DIR"/localhost/index.html > $OUTPUT_DIR/linkchecker.html \


### PR DESCRIPTION
The site returns 404 if queried by `wget` without user agent, but
works fine otherwise. Instead of trying to do something smart, we
assume that ETH will be around longer than the seL4 website.
