### PR TITLE
multiline message handling changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,10 +117,8 @@ jobs:
             echo "The HTML5 validator found some issues! Review them [here](https://htmlpreview.github.io/?https://github.com/seL4/website_pr_hosting/blob/PR_${{ github.event.number }}/localhost/pr_checks/validator.log)" >> msg.txt
           fi
           export MSG=$(cat msg.txt)
-          # The follow lines are to preserve newlines
-          MSG="${MSG//'%'/'%25'}"
-          MSG="${MSG//$'\n'/'%0A'}"
-          MSG="${MSG//$'\r'/'%0D'}"
+          # The following replaces newlines with the string '\n' for the JS call further below
+          MSG="${MSG//$'\n'/'\n'}"
           echo "MSG=$MSG" >> $GITHUB_ENV
       - name: Print message
         run: |


### PR DESCRIPTION
I initially thought the culprit was the different handling of newlines in `env` described here:
<https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable>

But it turns out it's the javascript action further below in the script, which just wanted `\n` quoted in its input string.