### PR TITLE
Move News to a subdirectory; split by year.

### DIFF
--- a/content/home.pml
+++ b/content/home.pml
@@ -17,7 +17,7 @@
 
 
 
-<a href="news.pml">
+<a href="news/">
 <div class="news">
 <div class="news-clearfix">
   <div class="news-column news-title">

--- a/content/news/2020.pml
+++ b/content/news/2020.pml
@@ -3,15 +3,33 @@
     Copyright 2020 seL4 Project a Series of LF Projects, LLC.
     SPDX-License-Identifier: CC-BY-SA-4.0
 -->
-<h1>
-  News about
+<div class="row">
+ <div class="col">
+ <h1>
+  2020's News about
   <a href="/">seL4</a>
   and the
   <a href="/Foundation">seL4 Foundation</a>
-</h1>
+  </h1>
+ </div>
+ <div class="col">
 <%
-
+from os import listdir
+from os.path import isfile, join
+from ertos_config import cfg
+import re
+cfg.read('config.cfg')
+newsdir = cfg.get('core', 'content_dir') + '/news/'
+files =  sorted([f for f in listdir(newsdir) if re.match(r'^20[0-9][0-9]\.pml$', f)])
+reflist = []
+for x in files:
+    link = '/news/' + x[:4]
+    reflist.append('<a href="%s">%s</a>' % (link, x[:4]))
+reflist = ' '.join(reflist)
 %>
+Other News: <%=reflist%>
+ </div>
+</div>
 
 <!----------------------------------------------------------->
 

--- a/content/news/2020.pml
+++ b/content/news/2020.pml
@@ -1,0 +1,304 @@
+<!--<title>News about seL4 and the seL4 Foundation</title>-->
+<!--
+    Copyright 2020 seL4 Project a Series of LF Projects, LLC.
+    SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+<h1>
+  News about
+  <a href="/">seL4</a>
+  and the
+  <a href="/Foundation">seL4 Foundation</a>
+</h1>
+<%
+
+%>
+
+<!----------------------------------------------------------->
+
+<!----------------------------------------------------------->
+<div class="news-item">
+ 31 Dec 2020: seL4 YouTube Channel
+</div>
+<div>
+ <p>
+
+  There is now a <a
+  href="https://www.youtube.com/channel/UCIqVY1XFPOPIZ1z2A9TrmMA/about">YouTube
+  channel</a> run by the seL4 Foundation. It presently has two
+  playlists, one with the recordings of the seL4 material from this
+  year’s UNSW Advanced Operating Systems course, and one with seL4
+  Summit talks from Trustworthy Systems.
+
+  More to come, enjoy.
+
+ </p>
+</div>
+
+
+<!----------------------------------------------------------->
+<div class="news-item">
+ 9 Nov 2020: seL4 12.0.0 release
+</div>
+<div>
+ <p>
+
+   <a href="https://sel4.systems">
+     <img src="/images/seL4.svg"
+	  style="width:30%; padding-left:1em; float:right"
+	  alt="seL4" />
+   </a>
+
+  Announcing the releases of seL4, CAmkES and CapDL under the seL4
+  Foundation.  Below you can find links to release notes with updates
+  to other supporting projects to come before the end of the year.
+
+  Versioned Releases:</p>
+  <ul>
+  <li>
+  seL4 12.0.0 ~ <a href="https://docs.sel4.systems/releases/sel4/12.0.0">https://docs.sel4.systems/releases/sel4/12.0.0</a>
+  </li>
+  <li>
+  CAmkES 3.9.0 ~ <a href="https://docs.sel4.systems/releases/camkes/camkes-3.9.0">https://docs.sel4.systems/releases/camkes/camkes-3.9.0</a>
+  </li>
+  <li>
+  CapDL 0.2.0 ~ <a href="https://docs.sel4.systems/releases/capdl/0.2.0">https://docs.sel4.systems/releases/capdl/0.2.0</a>
+  </li>
+  </ul>
+
+
+
+</div>
+
+<!----------------------------------------------------------->
+<div class="news-item">
+ 15 Oct 2020: 3rd seL4 summit to take place on 15-18 Nov
+</div>
+<div>
+ <p>
+
+  The <a href="https://trustedcomputingcoe.org/summits/2020-summit/">3rd seL4
+  Summit</a> will take place (virtually) on 15–18 November (US East
+  Coast time).  The program features a tutorial and 3 days packed with
+  great talks and panels.
+
+  Presentations will be streamed according to the schedule and
+  available for download right after, and there will be an on-line
+  discussion forum.
+
+  Registration is only $80US
+
+
+ </p>
+</div>
+
+<!----------------------------------------------------------->
+<div class="news-item">
+ 22 Jul 2020: Adventium Labs joins the seL4 Foundation!
+</div>
+<div>
+ <p>
+
+   <a href="https://www.adventiumlabs.com">
+     <img src="/Foundation/Membership/LOGOS/adventium-labs.svg"
+	  style="width:40%; padding-left:1em; float:right"
+	  alt="Adventium Labs logo" />
+   </a>
+
+  We’re happy to announce the newest member of the seL4 Foundation:
+  Minneapolis-based company <a
+  href="https://www.adventiumlabs.com">Adventium Labs</a>.
+
+  Adventium Labs develops solutions for safe and secure
+  software-intensive complex systems, with specialties in separation
+  architectures, model-based system engineering, and mathematical
+  analysis technologies. They are leveraging these capabilities to
+  extend seL4 into safety and security critical industries, including
+  medical devices, defense and commercial avionics, and industrial
+  control.
+
+
+ </p>
+</div>
+
+<!----------------------------------------------------------->
+<div class="news-item">
+  9 Jun 2020: functional correctness proof of seL4 RISC-V
+</div>
+<div>
+ <p>
+
+    <a href="https://riscv.org">
+      <img src="/Foundation/Membership/LOGOS/RISC-V.svg"
+	   style="width: 15%;  padding-left:10px;  float:right"
+	   alt="RISC-V logo" />
+    </a>
+
+    RISC-V (RV64) is the third ISA with verified seL4. The functional
+    correctness proof of seL4 on the RV64 ISA has
+    completed. Congratulations to the awesome Proof Engineering Team of
+    the Trustworthy Systems group on achieving this major milestone for
+    seL4! And many thanks to HENSOLDT Cyber for making it possible.
+ </p>
+
+ <p>
+   What we have now is the refinement proof from the seL4 formal spec
+   to the C implementation, putting RV64 on the same level as x64 in
+   terms of seL4 verification. The binary verification, which extends
+   this refinement to the binary code of the kernel is progressing,
+   stay tuned for more news on that in the foreseeable future.
+ </p>
+
+ <p>
+   More on this in this <a
+			  href="https://microkerneldude.wordpress.com/2020/06/09/sel4-is-verified-on-risc-v/">blog
+     post</a>.
+ </p>
+</div>
+
+
+
+<!----------------------------------------------------------->
+<div class="news-item">
+  2 Jun 2020: UNSW seL4 teaching videos available
+</div>
+<div>
+ <p>
+
+    <a href="https://www.unsw.edu.au">
+      <img src="/Foundation/Membership/LOGOS/UNSW.svg"
+	   style="width: 15%;  padding-left:10px;  float:right"
+	   alt="UNSW logo" />
+    </a>
+
+  Yet another contribution of <a href="https://www.unsw.edu.au">UNSW
+  Sydney</a> to the seL4 community: This year Gernot Heiser is making
+  the seL4-related videos from his UNSW Advanced Operating Systems
+  class freely available. You’ll find them at
+  the <a href="https://www.youtube.com/playlist?list=PLbSaCpDlfd6qLbEsKquVo3--0gwYBmrUV">UNSW
+      CSeLearning COMP9242 YouTube channel</a>.
+ </p>
+
+ <p>
+  At present there are the first two modules, which provide some
+  background on microkernels and seL4, and discuss the seL4 API. More
+  material will show up over the next two months.
+ </p>
+
+ <p>
+  The complete course material, including all lecture slides, the
+  project spec and code, are available, as always, from the <a
+  href="https://www.cse.unsw.edu.au/~cs9242/current/">COMP9042 web
+  site</a>.
+ </p>
+</div>
+
+<!----------------------------------------------------------->
+<div class="news-item">
+  25 May 2020: seL4 Foundation whitepaper released
+</div>
+<div>
+ <p>
+
+   <a href="/About/seL4-whitepaper.pdf">
+   <img src="About/whitepaper.svg"
+   style="width:15%; padding-left:1em; padding-bottom:1em; float:right"
+   alt="seL4 Whitepaper">
+   </a>
+
+
+   The whitepaper "The seL4 Microkernel – An Introduction" provides an
+   introduction to and overview of seL4. We explain what seL4 is (and
+   is not) and explore its defining features. We explain what makes
+   seL4 uniquely qualified as the operating-system kernel of choice
+   for security- and safety- critical systems, and generally embedded
+   and cyber-physical systems. In particular, we explain seL4’s
+   assurance story, its security- and safety-relevant features, and
+   its benchmark-setting performance. We also discuss typical usage
+   scenarios, including incremental cyber retrofit of legacy systems.
+
+   You can download <a href="https://sel4.systems/About/">here</a>.
+
+</p>
+</div>
+
+<!----------------------------------------------------------->
+<div class="news-item">
+  9 Jun 2020: Breakaway Consulting joins the seL4 Foundation!
+</div>
+<div>
+ <p>
+
+   <a href="https://brkawy.com">
+   <img src="/Foundation/Membership/LOGOS/Brkawy.png"
+   style="width:40%; padding-left:1em; float:right"
+   alt="Breakaway logo">
+   </a>
+
+
+   We’re happy to announce the first new member since the launch of
+   the seL4 Foundation: Sydney-based company <a
+   href="https://brkawy.com">Breakaway Consulting</a>.
+
+   Through Founder and Managing Director Ben Leslie, Breakaway comes
+   with 20 years of experience in L4 microkernels and systems based on
+   various L4 kernels. Prior to founding Breakaway, Ben was a student
+   with what is now the TS Group, and then VP Engineering of Open
+   Kernel Labs.
+
+   Breakaway offers consulting services on architecture, design and
+   implementation of seL4-based systems.
+
+</p>
+</div>
+
+
+
+
+
+<!----------------------------------------------------------->
+
+<div class="news-item">
+  7 Apr 2020: Launch of the seL4 Foundation
+</div>
+
+<div>
+  <p>
+
+   <img src="/images/mosaic.jpg"
+   style="width:30%; padding-left:1em; float:right"
+   alt="seL4 foundation launch" />
+
+   The <a href="https://trustworthy.systems">Trustworthy Systems
+   group</a> is excited to announce the creation of the <a
+   href="/Foundation/">seL4 Foundation</a>. Its aim is to provide a
+   neutral and independent organisation to ensure the longevity of
+   seL4, and grow its ecosystem of adopters and contributors.
+
+   It has a <a href="/Foundation/Board/">high-profile Board</a>
+   consisting of Gernot Heiser (Chair), June Andronick, Gerwin Klein,
+   John Launchbury, Sascha Kegreiß, Daniel Potts.
+
+   It already has a number of members, including major adopters
+   HENSOLDT Cyber and Ghost Systems, and providers of services for
+   seL4, Cog Systems and DornerWorks. Please check the <a
+   href="/Foundation/Membership/">membership page</a> for details and
+   how to join.
+
+   The seL4 Foundation is set up under the Linux Foundation, which
+   provides a mature and well-known framework.
+  </p>
+
+  <p>
+
+   More information on the <a
+   href="https://microkerneldude.wordpress.com/2020/04/07/the-sel4-foundation-what-and-why/">Blog
+   post</a> about "The seL4 Foundation &mdash; What and Why", and in
+   the press releases from <a
+   href="https://www.linuxfoundation.org/press-release/2020/04/sel4-microkernel-optimized-for-security-gets-support-of-linux-foundation/">the
+   Linux Foundation</a> and from <a
+   href="https://www.csiro.au/en/News/News-releases/2020/seL4-developers-create-open-source-foundation">CSIRO's
+   Data61</a>.
+  </p>
+</div>
+<div class="news-finish">
+</div>

--- a/content/news/2020.pml
+++ b/content/news/2020.pml
@@ -200,7 +200,7 @@
  <p>
 
    <a href="/About/seL4-whitepaper.pdf">
-   <img src="About/whitepaper.svg"
+   <img src="/About/whitepaper.svg"
    style="width:15%; padding-left:1em; padding-bottom:1em; float:right"
    alt="seL4 Whitepaper">
    </a>

--- a/content/news/2021.pml
+++ b/content/news/2021.pml
@@ -1,20 +1,35 @@
 <!--<title>News about seL4 and the seL4 Foundation</title>-->
 <!--
-    Copyright 2020 seL4 Project a Series of LF Projects, LLC.
+    Copyright 2021 seL4 Project a Series of LF Projects, LLC.
     SPDX-License-Identifier: CC-BY-SA-4.0
 -->
-<h1>
-  News about
-  <a href="home.pml">seL4</a>
-  and the
-  <a href="/Foundation">seL4 Foundation</a>
-</h1>
-
-
-
-
-
-<!----------------------------------------------------------->
+<div class="row">
+ <div class="col">
+  <h1>
+    News about
+    <a href="/">seL4</a>
+    and the
+    <a href="/Foundation">seL4 Foundation</a>
+  </h1>
+ </div>
+ <div class="col">
+<%
+from os import listdir
+from os.path import isfile, join
+from ertos_config import cfg
+import re
+cfg.read('config.cfg')
+newsdir = cfg.get('core', 'content_dir') + '/news/'
+files =  sorted([f for f in listdir(newsdir) if re.match(r'^20[0-9][0-9]\.pml$', f)])
+reflist = []
+for x in files:
+    link = '/news/' + x[:4]
+    reflist.append('<a href="%s">%s<a>' % (link, x[:4]))
+reflist = ' '.join(reflist)
+%>
+Older News: <%=reflist%>
+ </div>
+</div>
 
 <!--
 <div class="news-item">
@@ -38,34 +53,6 @@
  </p>
 </div>
 -->
-
-<!----------------------------------------------------------->
-
-<div class="news-item">
-  10 Sep 2021: Xcalibyte webinar by Gernot Heiser on seL4 on Sep 16, 2021
-</div>
-<div>
- <p>
-
-   <a href="https://xcalibyte.com">
-     <img src="/Foundation/Membership/LOGOS/xcalibyte.svg"
-	  style="width: 15%;  padding-left:10px;  float:right"
-	  alt="Xcalibyte logo">
-   </a>
-
-   Xcalibyte, a member of the seL4 Foundation, is hosting a webinar on Sep 16,
-   2021, given by Gernot Heiser, seL4 Foundation Chairman & Scientia Professor,
-   UNSW Sydney, and Yuning Liang, CEO & co-founder, Xcalibyte. The topic will be
-   ‘The seL4 Microkernel: Proved Security for Cyberphysical Systems’.
-
-</p>
-<p>
-
-   To register: <a
-   href="https://www.bagevent.com/event/7771850">https://www.bagevent.com/event/7771850</a>.
-
- </p>
-</div>
 
 <!----------------------------------------------------------->
 
@@ -263,10 +250,10 @@
  <p>
    The seL4 community is now definitely global. Still we would normally have a
    physical party in Sydney, but won’t be able to due to the renewed Covid-19
-   restrictions – so we’ll all be remote ;-)
+   restrictions &mdash; so we’ll all be remote ;-)
  </p>
  <div class="highlight">
-  <img src="images/seL4.svg" style="width:15%; padding-left:1em;" alt="seL4"><p>
+  <img src="/images/seL4.svg" style="width:15%; padding-left:1em;" alt="seL4"><p>
    Happy seL4 Day everyone!</p>
  </div>
  <p>
@@ -375,7 +362,7 @@
    <a href="https://secondstate.io">
      <img src="/Foundation/Membership/LOGOS/secondstate.svg"
 	  style="width: 15%;  padding-left:10px;  float:right"
-	  alt="Second state logo" />
+	  alt="Xcalibyte logo" />
    </a>
 
    The seL4 Foundation
@@ -416,8 +403,8 @@
   <table>
     <tr>
       <td>
-	<a href="Foundation/Board/Horizon-Feng.jpg"><img
-						      src="Foundation/Board/Horizon-Feng-s.jpg"
+	<a href="/Foundation/Board/Horizon-Feng.jpg"><img
+						      src="/Foundation/Board/Horizon-Feng-s.jpg"
 					alt="Dr Feng Zhou" width="80"
 						      /></a>
 	&nbsp; &nbsp;
@@ -433,8 +420,8 @@
 
     <tr>
       <td>
-	<a href="Foundation/Board/Li-Ian.png"><img
-					src="Foundation/Board/Li-Ian-s.png"
+	<a href="/Foundation/Board/Li-Ian.png"><img
+					src="/Foundation/Board/Li-Ian-s.png"
 					alt="Ian Xu" width="80" /></a>
 	&nbsp; &nbsp;
       </td>
@@ -449,8 +436,8 @@
 
     <tr>
       <td>
-	<a href="Foundation/Board/Jump-Matt.jpg"><img
-					src="Foundation/Board/Jump-Matt-s.jpg"
+	<a href="/Foundation/Board/Jump-Matt.jpg"><img
+					src="/Foundation/Board/Jump-Matt-s.jpg"
 					alt="Dr Matthew P. Grosvenor"
 					width="80" /></a>
 	&nbsp; &nbsp;
@@ -467,8 +454,8 @@
 
     <tr>
       <td>
-	<a href="Foundation/Board/NIO-Qiyan.png"><img
-						   src="Foundation/Board/NIO-Qiyan-s.png"
+	<a href="/Foundation/Board/NIO-Qiyan.png"><img
+						   src="/Foundation/Board/NIO-Qiyan-s.png"
 						   alt="Qiyan Wang"
 						   width="80" /></a>
       </td>
@@ -485,7 +472,7 @@
 
   <p>
     The four new members join five continuing members on
-    the <a href="Foundation/Board/">seL4 Board</a>, taking the size of
+    the <a href="/Foundation/Board/">seL4 Board</a>, taking the size of
     the Board to nine.
   </p>
 </div>
@@ -1186,294 +1173,5 @@
     The seL4 Foundation welcomes <a href="https://www.penten.com">Penten Pty Ltd</a> as our newest member. Penten is based in Canberra, Australia, and specialises in secure communications technology and artificial intelligence. Penten has been developing seL4-based products for a number of years, some of which are in daily use in multiple defence forces.
  </p>
 </div>
-
-<!----------------------------------------------------------->
-<div class="news-item">
- 31 Dec 2020: seL4 YouTube Channel
-</div>
-<div>
- <p>
-
-  There is now a <a
-  href="https://www.youtube.com/channel/UCIqVY1XFPOPIZ1z2A9TrmMA/about">YouTube
-  channel</a> run by the seL4 Foundation. It presently has two
-  playlists, one with the recordings of the seL4 material from this
-  year’s UNSW Advanced Operating Systems course, and one with seL4
-  Summit talks from Trustworthy Systems.
-
-  More to come, enjoy.
-
- </p>
-</div>
-
-
-<!----------------------------------------------------------->
-<div class="news-item">
- 9 Nov 2020: seL4 12.0.0 release
-</div>
-<div>
- <p>
-
-   <a href="https://sel4.systems">
-     <img src="/images/seL4.svg"
-	  style="width:30%; padding-left:1em; float:right"
-	  alt="seL4" />
-   </a>
-
-  Announcing the releases of seL4, CAmkES and CapDL under the seL4
-  Foundation.  Below you can find links to release notes with updates
-  to other supporting projects to come before the end of the year.
-
-  Versioned Releases:</p>
-  <ul>
-  <li>
-  seL4 12.0.0 ~ <a href="https://docs.sel4.systems/releases/sel4/12.0.0">https://docs.sel4.systems/releases/sel4/12.0.0</a>
-  </li>
-  <li>
-  CAmkES 3.9.0 ~ <a href="https://docs.sel4.systems/releases/camkes/camkes-3.9.0">https://docs.sel4.systems/releases/camkes/camkes-3.9.0</a>
-  </li>
-  <li>
-  CapDL 0.2.0 ~ <a href="https://docs.sel4.systems/releases/capdl/0.2.0">https://docs.sel4.systems/releases/capdl/0.2.0</a>
-  </li>
-  </ul>
-
-
-
-</div>
-
-<!----------------------------------------------------------->
-<div class="news-item">
- 15 Oct 2020: 3rd seL4 summit to take place on 15-18 Nov
-</div>
-<div>
- <p>
-
-  The <a href="https://trustedcomputingcoe.org/summits/2020-summit/">3rd seL4
-  Summit</a> will take place (virtually) on 15–18 November (US East
-  Coast time).  The program features a tutorial and 3 days packed with
-  great talks and panels.
-
-  Presentations will be streamed according to the schedule and
-  available for download right after, and there will be an on-line
-  discussion forum.
-
-  Registration is only $80US
-
-
- </p>
-</div>
-
-<!----------------------------------------------------------->
-<div class="news-item">
- 22 Jul 2020: Adventium Labs joins the seL4 Foundation!
-</div>
-<div>
- <p>
-
-   <a href="https://www.adventiumlabs.com">
-     <img src="/Foundation/Membership/LOGOS/adventium-labs.svg"
-	  style="width:40%; padding-left:1em; float:right"
-	  alt="Adventium Labs logo" />
-   </a>
-
-  We’re happy to announce the newest member of the seL4 Foundation:
-  Minneapolis-based company <a
-  href="https://www.adventiumlabs.com">Adventium Labs</a>.
-
-  Adventium Labs develops solutions for safe and secure
-  software-intensive complex systems, with specialties in separation
-  architectures, model-based system engineering, and mathematical
-  analysis technologies. They are leveraging these capabilities to
-  extend seL4 into safety and security critical industries, including
-  medical devices, defense and commercial avionics, and industrial
-  control.
-
-
- </p>
-</div>
-
-<!----------------------------------------------------------->
-<div class="news-item">
-  9 Jun 2020: functional correctness proof of seL4 RISC-V
-</div>
-<div>
- <p>
-
-    <a href="https://riscv.org">
-      <img src="/Foundation/Membership/LOGOS/RISC-V.svg"
-	   style="width: 15%;  padding-left:10px;  float:right"
-	   alt="RISC-V logo" />
-    </a>
-
-    RISC-V (RV64) is the third ISA with verified seL4. The functional
-    correctness proof of seL4 on the RV64 ISA has
-    completed. Congratulations to the awesome Proof Engineering Team of
-    the Trustworthy Systems group on achieving this major milestone for
-    seL4! And many thanks to HENSOLDT Cyber for making it possible.
- </p>
-
- <p>
-   What we have now is the refinement proof from the seL4 formal spec
-   to the C implementation, putting RV64 on the same level as x64 in
-   terms of seL4 verification. The binary verification, which extends
-   this refinement to the binary code of the kernel is progressing,
-   stay tuned for more news on that in the foreseeable future.
- </p>
-
- <p>
-   More on this in this <a
-			  href="https://microkerneldude.wordpress.com/2020/06/09/sel4-is-verified-on-risc-v/">blog
-     post</a>.
- </p>
-</div>
-
-
-
-<!----------------------------------------------------------->
-<div class="news-item">
-  2 Jun 2020: UNSW seL4 teaching videos available
-</div>
-<div>
- <p>
-
-    <a href="https://www.unsw.edu.au">
-      <img src="/Foundation/Membership/LOGOS/UNSW.svg"
-	   style="width: 15%;  padding-left:10px;  float:right"
-	   alt="UNSW logo" />
-    </a>
-
-  Yet another contribution of <a href="https://www.unsw.edu.au">UNSW
-  Sydney</a> to the seL4 community: This year Gernot Heiser is making
-  the seL4-related videos from his UNSW Advanced Operating Systems
-  class freely available. You’ll find them at
-  the <a href="https://www.youtube.com/playlist?list=PLbSaCpDlfd6qLbEsKquVo3--0gwYBmrUV">UNSW
-      CSeLearning COMP9242 YouTube channel</a>.
- </p>
-
- <p>
-  At present there are the first two modules, which provide some
-  background on microkernels and seL4, and discuss the seL4 API. More
-  material will show up over the next two months.
- </p>
-
- <p>
-  The complete course material, including all lecture slides, the
-  project spec and code, are available, as always, from the <a
-  href="https://www.cse.unsw.edu.au/~cs9242/current/">COMP9042 web
-  site</a>.
- </p>
-</div>
-
-<!----------------------------------------------------------->
-<div class="news-item">
-  25 May 2020: seL4 Foundation whitepaper released
-</div>
-<div>
- <p>
-
-   <a href="/About/seL4-whitepaper.pdf">
-   <img src="About/whitepaper.svg"
-   style="width:15%; padding-left:1em; padding-bottom:1em; float:right"
-   alt="seL4 Whitepaper">
-   </a>
-
-
-   The whitepaper "The seL4 Microkernel – An Introduction" provides an
-   introduction to and overview of seL4. We explain what seL4 is (and
-   is not) and explore its defining features. We explain what makes
-   seL4 uniquely qualified as the operating-system kernel of choice
-   for security- and safety- critical systems, and generally embedded
-   and cyber-physical systems. In particular, we explain seL4’s
-   assurance story, its security- and safety-relevant features, and
-   its benchmark-setting performance. We also discuss typical usage
-   scenarios, including incremental cyber retrofit of legacy systems.
-
-   You can download <a href="https://sel4.systems/About/">here</a>.
-
-</p>
-</div>
-
-<!----------------------------------------------------------->
-<div class="news-item">
-  9 Jun 2020: Breakaway Consulting joins the seL4 Foundation!
-</div>
-<div>
- <p>
-
-   <a href="https://brkawy.com">
-   <img src="/Foundation/Membership/LOGOS/Brkawy.png"
-   style="width:40%; padding-left:1em; float:right"
-   alt="Breakaway logo">
-   </a>
-
-
-   We’re happy to announce the first new member since the launch of
-   the seL4 Foundation: Sydney-based company <a
-   href="https://brkawy.com">Breakaway Consulting</a>.
-
-   Through Founder and Managing Director Ben Leslie, Breakaway comes
-   with 20 years of experience in L4 microkernels and systems based on
-   various L4 kernels. Prior to founding Breakaway, Ben was a student
-   with what is now the TS Group, and then VP Engineering of Open
-   Kernel Labs.
-
-   Breakaway offers consulting services on architecture, design and
-   implementation of seL4-based systems.
-
-</p>
-</div>
-
-
-
-
-
-<!----------------------------------------------------------->
-
-<div class="news-item">
-  7 Apr 2020: Launch of the seL4 Foundation
-</div>
-
-<div>
-  <p>
-
-   <img src="/images/mosaic.jpg"
-   style="width:30%; padding-left:1em; float:right"
-   alt="seL4 foundation launch" />
-
-   The <a href="https://trustworthy.systems">Trustworthy Systems
-   group</a> is excited to announce the creation of the <a
-   href="/Foundation/">seL4 Foundation</a>. Its aim is to provide a
-   neutral and independent organisation to ensure the longevity of
-   seL4, and grow its ecosystem of adopters and contributors.
-
-   It has a <a href="/Foundation/Board/">high-profile Board</a>
-   consisting of Gernot Heiser (Chair), June Andronick, Gerwin Klein,
-   John Launchbury, Sascha Kegreiß, Daniel Potts.
-
-   It already has a number of members, including major adopters
-   HENSOLDT Cyber and Ghost Systems, and providers of services for
-   seL4, Cog Systems and DornerWorks. Please check the <a
-   href="/Foundation/Membership/">membership page</a> for details and
-   how to join.
-
-   The seL4 Foundation is set up under the Linux Foundation, which
-   provides a mature and well-known framework.
-  </p>
-
-  <p>
-
-   More information on the <a
-   href="https://microkerneldude.wordpress.com/2020/04/07/the-sel4-foundation-what-and-why/">Blog
-   post</a> about "The seL4 Foundation &mdash; What and Why", and in
-   the press releases from <a
-   href="https://www.linuxfoundation.org/press-release/2020/04/sel4-microkernel-optimized-for-security-gets-support-of-linux-foundation/">the
-   Linux Foundation</a> and from <a
-   href="https://www.csiro.au/en/News/News-releases/2020/seL4-developers-create-open-source-foundation">CSIRO's
-   Data61</a>.
-  </p>
-</div>
-
-
-
 <div class="news-finish">
 </div>

--- a/content/news/2021.pml
+++ b/content/news/2021.pml
@@ -75,7 +75,7 @@ Older News: <%=reflist%>
 </p>
 <p>
    To register: <a
-   href="https://www.bagevent.com/event/7771850">https://www.bagevent.com/event/7771850</a>.
+   href="http://xcalscan.mikecrm.com/Uw4y9HU">http://xcalscan.mikecrm.com/Uw4y9HU</a>.
  </p>
 </div>
 

--- a/content/news/2021.pml
+++ b/content/news/2021.pml
@@ -387,7 +387,7 @@ Older News: <%=reflist%>
    <a href="https://secondstate.io">
      <img src="/Foundation/Membership/LOGOS/secondstate.svg"
 	  style="width: 15%;  padding-left:10px;  float:right"
-	  alt="Xcalibyte logo" />
+	  alt="Second State logo" />
    </a>
 
    The seL4 Foundation

--- a/content/news/2021.pml
+++ b/content/news/2021.pml
@@ -698,7 +698,7 @@ Older News: <%=reflist%>
 <div>
   <p>
     <a href="https://sel4.systems">
-      <img src="images/seL4.svg" style="width:15%; padding-left:1em;
+      <img src="/images/seL4.svg" style="width:15%; padding-left:1em;
 	   float:right" alt="seL4" />
     </a>
 

--- a/content/news/2021.pml
+++ b/content/news/2021.pml
@@ -24,7 +24,7 @@ files =  sorted([f for f in listdir(newsdir) if re.match(r'^20[0-9][0-9]\.pml$',
 reflist = []
 for x in files:
     link = '/news/' + x[:4]
-    reflist.append('<a href="%s">%s<a>' % (link, x[:4]))
+    reflist.append('<a href="%s">%s</a>' % (link, x[:4]))
 reflist = ' '.join(reflist)
 %>
 Older News: <%=reflist%>

--- a/content/news/2021.pml
+++ b/content/news/2021.pml
@@ -55,6 +55,31 @@ Older News: <%=reflist%>
 -->
 
 <!----------------------------------------------------------->
+<div class="news-item">
+  10 Sep 2021: Xcalibyte webinar by Gernot Heiser on seL4 on Sep 16, 2021
+</div>
+<div>
+ <p>
+
+   <a href="https://xcalibyte.com">
+     <img src="/Foundation/Membership/LOGOS/xcalibyte.svg"
+	  style="width: 15%;  padding-left:10px;  float:right"
+	  alt="Xcalibyte logo">
+   </a>
+
+   Xcalibyte, a member of the seL4 Foundation, is hosting a webinar on Sep 16,
+   2021, given by Gernot Heiser, seL4 Foundation Chairman & Scientia Professor,
+   UNSW Sydney, and Yuning Liang, CEO & co-founder, Xcalibyte. The topic will be
+   ‘The seL4 Microkernel: Proved Security for Cyberphysical Systems’.
+
+</p>
+<p>
+   To register: <a
+   href="https://www.bagevent.com/event/7771850">https://www.bagevent.com/event/7771850</a>.
+ </p>
+</div>
+
+<!----------------------------------------------------------->
 
 <div class="news-item">
   31 Aug 2021: Ghost donates to the seL4 Foundation

--- a/content/news/home.pml
+++ b/content/news/home.pml
@@ -1,0 +1,18 @@
+<%
+#    Copyright 2021 seL4 Project a Series of LF Projects, LLC.
+#    SPDX-License-Identifier: CC-BY-SA-4.0
+#
+# this has to happen before any content that
+# might otherwise be sent to the client.
+# Find the latest file in ./news/ and redirect to that.
+from os import listdir
+from os.path import isfile, join
+import re
+from ertos_config import cfg
+cfg.read('config.cfg')
+newsdir = cfg.get('core', 'content_dir') + '/news/'
+files = [f for f in listdir(newsdir) if re.match(r'^20[0-9][0-9]\.pml$', f)]
+latest = sorted(files, reverse=True)[0]
+psp.redirect('/news/' + latest[:4])
+%>
+<!--<title>News about seL4 and the seL4 Foundation</title>-->


### PR DESCRIPTION
As we get more and more news, having it all in one
file becomes unwieldy.  Plus, we would like to be able to have
stable URLs to news and news items.

Therefore, split news into per-year files, named 'news/2021.pml',
'news/2020.pml' and so on; and use the Python templating engine
to build indices, and to redirect from 'sel4.systems/news' to the
highest numbered news file.

Signed-off-by: Peter Chubb <peter.chubb@unsw.edu.au>