### PR TITLE
add open video chat for developers

### DIFF
--- a/content/contact/home.pml
+++ b/content/contact/home.pml
@@ -34,7 +34,42 @@ Discussion about using and developing seL4 (questions, suggestions, updates, etc
 <li><a href="https://mattermost.trustworthy.systems/sel4-external/">Mattermost chat</a></li>
 <li>IRC: we used to have an IRC channel, but we no longer monitor that, so do not recommend using it.</li>
 </ul>
-
+<p>
+We are also hosting an <a href="https://unsw.zoom.us/j/82640784431">open video
+chat hangout</a> every two weeks (Tuesday afternoon/evening US/EU, Wednesday
+morning Asia/Australia) to bring seL4 developers together. There is no strict
+agenda, anybody can join for technical discussions about seL4, related
+repositories and projects, or general questions and answers. Members from the
+technical steering committee (TSC) will try to be there, but these are not
+TSC meetings where formal decisions are made.<br>
+The next sessions are:
+</p>
+<ul>
+  <li>
+    Topic: seL4 boot code
+    <ul>
+      <li>Sydney: Wed, Nov 3, 8am</li>
+      <li>Central Europe: Tue, Nov 2, 10pm</li>
+      <li>US Pacific Time: Tue, Nov 2, 2pm</li>
+    </ul>
+  </li>
+  <li>
+    Topic: <i>open</i>
+    <ul>
+      <li>Sydney: Wed, Nov 17, 8am</li>
+      <li>Central Europe: Tue, Nov 16, 10pm</li>
+      <li>US Pacific Time: Tue, Nov 16, 2pm</li>
+    </ul>
+  </li>
+  <li>
+    Topic: <i>open</i>
+    <ul>
+      <li>Sydney: Wed, Dec 1, 8am</li>
+      <li>Central Europe: Tue, Nov 30, 10pm</li>
+      <li>US Pacific Time: Tue, Nov 30, 2pm</li>
+    </ul>
+  </li>
+</ul>
 <p>
 RFC (request for comments) proposing new features for seL4
 </p>


### PR DESCRIPTION
add open video chat for developers, 
re-PR of https://github.com/seL4/website/pull/149, but this time from a "local" branch so the action work.

> Thanks for adding that. We'll have to make sure to update this every two weeks so that it does not become stale, but I'm happy to try this for a while.

Yes, that will be a permanent task - unless we use some embedded Javascript that calculates the next meeting dynamically.