### PR TITLE
docker: exclude flaky link in checker

### DIFF
--- a/docker/linkchecker.sh
+++ b/docker/linkchecker.sh
@@ -26,6 +26,7 @@ linkchecker \
     --ignore-url="/lists/" \
     --ignore-url="https://ethz.ch/en.html" \
     --ignore-url="https://horizon.ai" \
+    --ignore-url="https://nio.com" \
     --check-extern \
     --output html \
     "$OUTPUT_SNAPSHOT_DIR"/localhost/index.html > $OUTPUT_DIR/linkchecker.html \


### PR DESCRIPTION
The link checker seems to have intermittent issues with https://nio.com. Since we know this link is good, exclude it from the check.
