### PR TITLE
docker: enable docker build on Apple M1

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,4 +10,4 @@ preview: build
 	cd ..; docker run -p 8080:80 -v `pwd`:/mnt -ti --entrypoint bash $(TAG) /mnt/docker/run-local.sh
 
 build:
-	cd ..; docker build -t $(TAG) -f docker/Dockerfile .
+	cd ..; docker/build.sh -t $(TAG) -f docker/Dockerfile .

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Copyright 2022, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+case "$(uname -m)" in
+    arm64)
+        DOCKER="docker buildx build --platform linux/amd64"
+        ;;
+    *)
+        DOCKER="docker build"
+        ;;
+esac
+
+exec $DOCKER "$@"


### PR DESCRIPTION
Since the purpose of the container mostly is to check changes locally, we currently just run the build in x86 emulation mode for M1.

Getting a native M1 build running would need an apache python module on arm64 for python 3.7 and Debian buster, or an overall working Debian bullseye setup.
