### PR TITLE
linkchecker: ignore rtx.com

### DIFF
--- a/docker/linkchecker.sh
+++ b/docker/linkchecker.sh
@@ -28,6 +28,7 @@ linkchecker \
     --ignore-url="https://horizon.ai" \
     --ignore-url="https://nio.com" \
     --ignore-url="https://lixiang.com" \
+    --ignore-url="https://rtx.com" \
     --check-extern \
     --output html \
     "$OUTPUT_SNAPSHOT_DIR"/localhost/index.html > $OUTPUT_DIR/linkchecker.html \


### PR DESCRIPTION
Looks like the site doesn't like link checkers.
