### PR TITLE
github: disable preview for PRs for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,6 +132,7 @@ jobs:
     name: "PR Comment"
     runs-on: 'ubuntu-latest'
     needs: [snapshot]
+    if: ${{ needs.snapshot.outputs.linkchecker_failed || needs.snapshot.outputs.validator_failed }}
     env:
       LINKCHECK_MSG: ${{ needs.snapshot.outputs.linkcheck_msg }}
       VALIDATOR_MSG: ${{ needs.snapshot.outputs.validator_msg }}
@@ -141,7 +142,7 @@ jobs:
       - name: Build message
         id: msg
         run: |
-          echo "Preview your changes [here](https://htmlpreview.github.io/?https://github.com/seL4/website_pr_hosting/blob/PR_${{ github.event.number }}/index.html)" > msg.txt
+          # echo "Preview your changes [here](https://htmlpreview.github.io/?https://github.com/seL4/website_pr_hosting/blob/PR_${{ github.event.number }}/index.html)" > msg.txt
           if ${{ needs.snapshot.outputs.linkchecker_failed }}; then
             echo "" >> msg.txt
             echo "The link checker found some issues!" >> msg.txt


### PR DESCRIPTION
Only comment when linkchecker or validator failed, but do not show link to preview.