### PR TITLE
Fix youtube links summit 2023

### DIFF
--- a/Foundation/Summit/2023/abstracts2023.html
+++ b/Foundation/Summit/2023/abstracts2023.html
@@ -24,184 +24,184 @@ redirect_from:
 <a href="slides/day1-01-gage.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-scoping-assurance">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-dynamic-sel4">{% include abstracts/2023/dynamic-sel4.html %}
-<a href="https://youtu.be/KTxz_UGGldA?si=ZmPV1JP5hmhaNZel" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-dynamic-sel4">{% include abstracts/dynamic-sel4.html %}
+<a href="https://youtu.be/hHihCvB1cJI?si=3C1-F2wLJnEMHLDE" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-02-brecknell.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-dynamic-sel4">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-formally-stepping">{% include abstracts/2023/formally-stepping.html %}
-<a href="https://youtu.be/tpooLn2aJJ4?si=v3HLLkrDN2ikdNa6" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-formally-stepping">{% include abstracts/formally-stepping.html %}
+<a href="https://youtu.be/YnjpB5GlIsA?si=Nc8NuVBz_6oqi7Kp" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-03-frost.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-formally-stepping">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-reducing-reliance">{% include abstracts/2023/reducing-reliance.html %}
-<a href="https://youtu.be/bxlE5AiQQXU?si=_n9CYMSfSGELmckg" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-reducing-reliance">{% include abstracts/reducing-reliance.html %}
+<a href="https://youtu.be/XJTdhZqFONI?si=YNeFC0bfC_tMeH1N" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-04-klein.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-reducing-reliance">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-efficient-smp">{% include abstracts/2023/efficient-smp.html %}
-<a href="https://youtu.be/PE7cLQ1OTqM?si=mm5mZHFut1EZNDWd" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-efficient-smp">{% include abstracts/efficient-smp.html %}
+<a href="https://youtu.be/ePdaQDO5nhc?si=LMtGK8b2i7b91o0s" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-05-mcleod.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-efficient-smp">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-system-information">{% include abstracts/2023/system-information.html %}
-<a href="https://youtu.be/yk-8tb3ssHw?si=Z4QU0C0qlaSqLnut" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-system-information">{% include abstracts/system-information.html %}
+<a href="https://youtu.be/u-yhdme-o0k?si=zbYHmq0QxzmmeZzt" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-06-kuz.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-system-information">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-advancements-virtualization">{% include abstracts/2023/advancements-virtualization.html %}
-<a href="https://youtu.be/GlHMxTiD3wo?si=WlS_9tPEi7BtUqdL" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-advancements-virtualization">{% include abstracts/advancements-virtualization.html %}
+<a href="https://youtu.be/AsYB6yOAEYQ?si=jEewVOADm8NQv3bl" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-07-ahvenjärvi.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-advancements-virtualization">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-device">{% include abstracts/2023/sel4-device.html %}
-<a href="https://youtu.be/gDXsnBhNiQM?si=mgxC5xNNWiH0wabe" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-sel4-device">{% include abstracts/sel4-device.html %}
+<a href="https://youtu.be/be0_PSW0b5M?si=t7dB73HMk8hR9mk0" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-08-parker.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-device">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-rd-update">{% include abstracts/2023/rd-update.html %}
-<a href="https://youtu.be/D6SRIUMAZAA?si=a9jKZXa97uDQgLJY" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-rd-update">{% include abstracts/rd-update.html %}
+<a href="https://youtu.be/v16ycALKDLM?si=5eVX9qe2faJhDQyq" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-09-heiser.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-rd-update">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-experiences">{% include abstracts/2023/sel4-experiences.html %}
-<a href="https://youtu.be/bCRNTrZ9gx8?si=jA3paaa7efTwlG0M" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-sel4-experiences">{% include abstracts/sel4-experiences.html %}
+<a href="https://youtu.be/SsEuhby_U6k?si=9dPxuHINTNOcLgFR" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-10-guikema.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-experiences">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-from-zero">{% include abstracts/2023/from-zero.html %}
-<a href="https://youtu.be/ih3oxRS8PAU?si=m-PtD8uXo8OOzx0-" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-from-zero">{% include abstracts/from-zero.html %}
+<a href="https://youtu.be/Jsp2VMq3uDI?si=JucKo2C5ykhWaItl" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-11-felmeden.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-from-zero">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-crashing-for">{% include abstracts/2023/crashing-for.html %}
-<a href="https://youtu.be/9oxfqS6gUik?si=9ersOF3-REmUiR_k" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-crashing-for">{% include abstracts/crashing-for.html %}
+<a href="https://youtu.be/jAzo4J9mrrE?si=h5slswaN53Ws4Ncf" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-12-kuz.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-crashing-for">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-gold-kry10">{% include abstracts/2023/gold-kry10.html %}
-<a href="https://youtu.be/kUWmockNkUY?si=22QhHV2woeubBgXj" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-gold-kry10">{% include abstracts/gold-kry10.html %}
+<a href="https://youtu.be/1H5EQ4DrJeo?si=ZffQVqCmYRdZ4dfu" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-13-multerer.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-gold-kry10">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-cantripos">{% include abstracts/2023/cantripos.html %}
-<a href="https://youtu.be/yITE9AvlohY?si=zHtRHuyqaYdk_yCj" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-cantripos">{% include abstracts/cantripos.html %}
+<a href="https://youtu.be/-3SCCx-b61k?si=IpAa7ZHfBQf8Wd9l" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-01-leffler.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-cantripos">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-magnetite">{% include abstracts/2023/magnetite.html %}
-<a href="https://youtu.be/O66mgVMAA6E?si=Me6zb6t7DqCi57On" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-magnetite">{% include abstracts/magnetite.html %}
+<a href="https://youtu.be/UFF93HcQfEc?si=MrX9dEbI3b_CAamZ" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-02-furgala.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-magnetite">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-showcase-microkernel">{% include abstracts/2023/showcase-microkernel.html %}
-<a href="https://youtu.be/Kp-PsRZbbCc?si=_jYcxJgbgoLY3Hsr" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-showcase-microkernel">{% include abstracts/showcase-microkernel.html %}
+<a href="https://youtu.be/R9zRyYVReKU?si=Jj-BjHhlqIQbCjob" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-03-hussman.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-showcase-microkernel">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-rust-support">{% include abstracts/2023/rust-support.html %}
-<a href="https://youtu.be/J17lC124_9s?si=m0QguvsgDXOTlrtz" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-rust-support">{% include abstracts/rust-support.html %}
+<a href="https://youtu.be/jR2i4Y2Aq3o?si=rJSRRTD7Y-3Z6lUu" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-04-spinale.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-rust-support">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-microkit">{% include abstracts/2023/sel4-microkit.html %}
-<a href="https://youtu.be/QWMyvFuJ-WQ?si=aN9vwOjgYmNsJ37w" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-sel4-microkit">{% include abstracts/sel4-microkit.html %}
+<a href="https://youtu.be/1Y6uE3eZWKQ?si=9fIcnBFUlji0EOAj" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-05-velickovic.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-microkit">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-leveraging-rust">{% include abstracts/2023/leveraging-rust.html %}
-<a href="https://youtu.be/TeF0f0YcDOw?si=eCZA1ryWFpBZi5UR" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-leveraging-rust">{% include abstracts/leveraging-rust.html %}
+<a href="https://youtu.be/JmqSfTEg0u8?si=pPKmIWJ4_PrHxvfk" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-06-hamlin.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-leveraging-rust">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-panel">{% include abstracts/2023/panel.html %}
-<a href="https://youtu.be/e7-laSU2NS0?si=zP-36-6VWKaIM0xP" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-panel">{% include abstracts/panel.html %}
+<a href="https://youtu.be/PynVzpXRW-o?si=JR_9nGM3fwILHnJc" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 <br>
 <a href="program#p-panel">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-vmm">{% include abstracts/2023/sel4-vmm.html %}
-<a href="https://youtu.be/YtTM0jn4iN0?si=gG1o6Ygq6vYjWbkF" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-sel4-vmm">{% include abstracts/sel4-vmm.html %}
+<a href="https://youtu.be/a-JLqYVINxo?si=EjKQHSYPmGrlgLna" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-08-vanvossen.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-vmm">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-arm">{% include abstracts/2023/sel4-arm.html %}
-<a href="https://youtu.be/YeBqmRWQWrI?si=WNTDVL0iIODbOtL3" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-sel4-arm">{% include abstracts/sel4-arm.html %}
+<a href="https://youtu.be/VcufX8hZ5-o?si=zNc0rSodvxrm5DF8" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-09-atkins.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-arm">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-incremental-assurance">{% include abstracts/2023/incremental-assurance.html %}
-<a href="https://youtu.be/uLA6bbDzGyI?si=e9G9h2eZ_4oVjxo_" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-incremental-assurance">{% include abstracts/incremental-assurance.html %}
+<a href="https://youtu.be/c7UC2Rgj3n4?si=XCFZwqwZbTeERon1" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-10-podhradsky.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-incremental-assurance">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-iommu">{% include abstracts/2023/iommu.html %}
-<a href="https://youtu.be/83NvRf4zsJQ?si=FohEFUf2QCvGPiWk" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-iommu">{% include abstracts/iommu.html %}
+<a href="https://youtu.be/6knMCkB-Qvw?si=sd1etRZ3Y4Y_Z0Kc" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-12-mao.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-iommu">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-toward-verified">{% include abstracts/2023/toward-verified.html %}
-<a href="https://youtu.be/rkuqmizZjbw?si=ojlp7FRRoduiOXIQ" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-toward-verified">{% include abstracts/toward-verified.html %}
+<a href="https://youtu.be/wjrA0HlW9JQ?si=O-s5cyDWcgz_LxTY" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-11-rollins.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-toward-verified">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-gold-nio">{% include abstracts/2023/gold-nio.html %}
-<a href="https://youtu.be/HfvX2VbWp6c?si=TpCsq8GtYme0SY12" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-gold-nio">{% include abstracts/gold-nio.html %}
+<a href="https://youtu.be/W_Y3M6s4E9w?si=OHlpA1kppVWKtbyk" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-13-wang.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-gold-nio">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-gold-tii">{% include abstracts/2023/gold-tii.html %}
-<a href="https://youtu.be/NrtkpOHv8-k?si=ig8c4umBXrd5Y1cI" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-gold-tii">{% include abstracts/gold-tii.html %}
+<a href="https://youtu.be/MX_svP-Sopk?si=L7DBrBEMd7eIxNYs" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-14-dematos.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-gold-tii">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sig-community">{% include abstracts/2023/sig-community.html %}
-<a href="https://youtu.be/Z8TK83qx0NY?si=Yy8GpNi1KHEWYbwl" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-sig-community">{% include abstracts/sig-community.html %}
+<a href="https://youtu.be/ZHLePzGa4vs?si=2Jk9djA0IbBaO81G" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <br><a href="program#p-sig-community">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-virtualization">{% include abstracts/2023/sel4-virtualization.html %}
-<a href="https://www.youtube.com/watch?" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-sel4-virtualization">{% include abstracts/sel4-virtualization.html %}
+<!--a href="https://www.youtube.com/watch?" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a-->
 <br><a href="program#p-sel4-virtualization">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-building-commercial">{% include abstracts/2023/building-commercial.html %}
-<a href="https://youtu.be/pC2KdpTPstI?si=u9_u0RJ0xnyrfM14" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-building-commercial">{% include abstracts/building-commercial.html %}
+<a href="https://youtu.be/TSYXw4DIGXw?si=BGeO-2LhY1lGREJr" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day3-03-sebranek.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-building-commercial">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-riscv">{% include abstracts/2023/sel4-riscv.html %}
-<a href="https://youtu.be/7L-hLbxCkCc?si=52JqDj12s7tLqKa0" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-sel4-riscv">{% include abstracts/sel4-riscv.html %}
+<a href="https://youtu.be/QSo03imeTx8?si=x2Qx7DRZb82xnJ7b" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day3-04-dematos.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-riscv">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-trustworthy-measurements">{% include abstracts/2023/trustworthy-measurements.html %}
-<a href="https://youtu.be/tGRQFvVnmVU?si=Mhz7ofjOE7DDCZcR" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
+<div class="summit-abstract" id="a-trustworthy-measurements">{% include abstracts/trustworthy-measurements.html %}
+<a href="https://youtu.be/lyTyJKugoqU?si=mbT_WOp2fGZsbL1h" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day3-05-neises.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-trustworthy-measurements">See this talk in the program</a></div>

--- a/Foundation/Summit/2023/abstracts2023.html
+++ b/Foundation/Summit/2023/abstracts2023.html
@@ -24,183 +24,183 @@ redirect_from:
 <a href="slides/day1-01-gage.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-scoping-assurance">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-dynamic-sel4">{% include abstracts/dynamic-sel4.html %}
+<div class="summit-abstract" id="a-dynamic-sel4">{% include abstracts/2023/dynamic-sel4.html %}
 <a href="https://youtu.be/hHihCvB1cJI?si=3C1-F2wLJnEMHLDE" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-02-brecknell.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-dynamic-sel4">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-formally-stepping">{% include abstracts/formally-stepping.html %}
+<div class="summit-abstract" id="a-formally-stepping">{% include abstracts/2023/formally-stepping.html %}
 <a href="https://youtu.be/YnjpB5GlIsA?si=Nc8NuVBz_6oqi7Kp" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-03-frost.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-formally-stepping">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-reducing-reliance">{% include abstracts/reducing-reliance.html %}
+<div class="summit-abstract" id="a-reducing-reliance">{% include abstracts/2023/reducing-reliance.html %}
 <a href="https://youtu.be/XJTdhZqFONI?si=YNeFC0bfC_tMeH1N" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-04-klein.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-reducing-reliance">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-efficient-smp">{% include abstracts/efficient-smp.html %}
+<div class="summit-abstract" id="a-efficient-smp">{% include abstracts/2023/efficient-smp.html %}
 <a href="https://youtu.be/ePdaQDO5nhc?si=LMtGK8b2i7b91o0s" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-05-mcleod.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-efficient-smp">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-system-information">{% include abstracts/system-information.html %}
+<div class="summit-abstract" id="a-system-information">{% include abstracts/2023/system-information.html %}
 <a href="https://youtu.be/u-yhdme-o0k?si=zbYHmq0QxzmmeZzt" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-06-kuz.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-system-information">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-advancements-virtualization">{% include abstracts/advancements-virtualization.html %}
+<div class="summit-abstract" id="a-advancements-virtualization">{% include abstracts/2023/advancements-virtualization.html %}
 <a href="https://youtu.be/AsYB6yOAEYQ?si=jEewVOADm8NQv3bl" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-07-ahvenjärvi.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-advancements-virtualization">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-device">{% include abstracts/sel4-device.html %}
+<div class="summit-abstract" id="a-sel4-device">{% include abstracts/2023/sel4-device.html %}
 <a href="https://youtu.be/be0_PSW0b5M?si=t7dB73HMk8hR9mk0" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-08-parker.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-device">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-rd-update">{% include abstracts/rd-update.html %}
+<div class="summit-abstract" id="a-rd-update">{% include abstracts/2023/rd-update.html %}
 <a href="https://youtu.be/v16ycALKDLM?si=5eVX9qe2faJhDQyq" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-09-heiser.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-rd-update">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-experiences">{% include abstracts/sel4-experiences.html %}
+<div class="summit-abstract" id="a-sel4-experiences">{% include abstracts/2023/sel4-experiences.html %}
 <a href="https://youtu.be/SsEuhby_U6k?si=9dPxuHINTNOcLgFR" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-10-guikema.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-experiences">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-from-zero">{% include abstracts/from-zero.html %}
+<div class="summit-abstract" id="a-from-zero">{% include abstracts/2023/from-zero.html %}
 <a href="https://youtu.be/Jsp2VMq3uDI?si=JucKo2C5ykhWaItl" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-11-felmeden.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-from-zero">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-crashing-for">{% include abstracts/crashing-for.html %}
+<div class="summit-abstract" id="a-crashing-for">{% include abstracts/2023/crashing-for.html %}
 <a href="https://youtu.be/jAzo4J9mrrE?si=h5slswaN53Ws4Ncf" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-12-kuz.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-crashing-for">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-gold-kry10">{% include abstracts/gold-kry10.html %}
+<div class="summit-abstract" id="a-gold-kry10">{% include abstracts/2023/gold-kry10.html %}
 <a href="https://youtu.be/1H5EQ4DrJeo?si=ZffQVqCmYRdZ4dfu" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day1-13-multerer.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-gold-kry10">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-cantripos">{% include abstracts/cantripos.html %}
+<div class="summit-abstract" id="a-cantripos">{% include abstracts/2023/cantripos.html %}
 <a href="https://youtu.be/-3SCCx-b61k?si=IpAa7ZHfBQf8Wd9l" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-01-leffler.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-cantripos">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-magnetite">{% include abstracts/magnetite.html %}
+<div class="summit-abstract" id="a-magnetite">{% include abstracts/2023/magnetite.html %}
 <a href="https://youtu.be/UFF93HcQfEc?si=MrX9dEbI3b_CAamZ" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-02-furgala.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-magnetite">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-showcase-microkernel">{% include abstracts/showcase-microkernel.html %}
+<div class="summit-abstract" id="a-showcase-microkernel">{% include abstracts/2023/showcase-microkernel.html %}
 <a href="https://youtu.be/R9zRyYVReKU?si=Jj-BjHhlqIQbCjob" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-03-hussman.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-showcase-microkernel">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-rust-support">{% include abstracts/rust-support.html %}
+<div class="summit-abstract" id="a-rust-support">{% include abstracts/2023/rust-support.html %}
 <a href="https://youtu.be/jR2i4Y2Aq3o?si=rJSRRTD7Y-3Z6lUu" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-04-spinale.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-rust-support">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-microkit">{% include abstracts/sel4-microkit.html %}
+<div class="summit-abstract" id="a-sel4-microkit">{% include abstracts/2023/sel4-microkit.html %}
 <a href="https://youtu.be/1Y6uE3eZWKQ?si=9fIcnBFUlji0EOAj" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-05-velickovic.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-microkit">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-leveraging-rust">{% include abstracts/leveraging-rust.html %}
+<div class="summit-abstract" id="a-leveraging-rust">{% include abstracts/2023/leveraging-rust.html %}
 <a href="https://youtu.be/JmqSfTEg0u8?si=pPKmIWJ4_PrHxvfk" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-06-hamlin.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-leveraging-rust">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-panel">{% include abstracts/panel.html %}
+<div class="summit-abstract" id="a-panel">{% include abstracts/2023/panel.html %}
 <a href="https://youtu.be/PynVzpXRW-o?si=JR_9nGM3fwILHnJc" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 <br>
 <a href="program#p-panel">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-vmm">{% include abstracts/sel4-vmm.html %}
+<div class="summit-abstract" id="a-sel4-vmm">{% include abstracts/2023/sel4-vmm.html %}
 <a href="https://youtu.be/a-JLqYVINxo?si=EjKQHSYPmGrlgLna" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-08-vanvossen.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-vmm">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-arm">{% include abstracts/sel4-arm.html %}
+<div class="summit-abstract" id="a-sel4-arm">{% include abstracts/2023/sel4-arm.html %}
 <a href="https://youtu.be/VcufX8hZ5-o?si=zNc0rSodvxrm5DF8" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-09-atkins.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-arm">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-incremental-assurance">{% include abstracts/incremental-assurance.html %}
+<div class="summit-abstract" id="a-incremental-assurance">{% include abstracts/2023/incremental-assurance.html %}
 <a href="https://youtu.be/c7UC2Rgj3n4?si=XCFZwqwZbTeERon1" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-10-podhradsky.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-incremental-assurance">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-iommu">{% include abstracts/iommu.html %}
+<div class="summit-abstract" id="a-iommu">{% include abstracts/2023/iommu.html %}
 <a href="https://youtu.be/6knMCkB-Qvw?si=sd1etRZ3Y4Y_Z0Kc" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-12-mao.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-iommu">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-toward-verified">{% include abstracts/toward-verified.html %}
+<div class="summit-abstract" id="a-toward-verified">{% include abstracts/2023/toward-verified.html %}
 <a href="https://youtu.be/wjrA0HlW9JQ?si=O-s5cyDWcgz_LxTY" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-11-rollins.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-toward-verified">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-gold-nio">{% include abstracts/gold-nio.html %}
+<div class="summit-abstract" id="a-gold-nio">{% include abstracts/2023/gold-nio.html %}
 <a href="https://youtu.be/W_Y3M6s4E9w?si=OHlpA1kppVWKtbyk" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-13-wang.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-gold-nio">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-gold-tii">{% include abstracts/gold-tii.html %}
+<div class="summit-abstract" id="a-gold-tii">{% include abstracts/2023/gold-tii.html %}
 <a href="https://youtu.be/MX_svP-Sopk?si=L7DBrBEMd7eIxNYs" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day2-14-dematos.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-gold-tii">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sig-community">{% include abstracts/sig-community.html %}
+<div class="summit-abstract" id="a-sig-community">{% include abstracts/2023/sig-community.html %}
 <a href="https://youtu.be/ZHLePzGa4vs?si=2Jk9djA0IbBaO81G" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <br><a href="program#p-sig-community">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-virtualization">{% include abstracts/sel4-virtualization.html %}
+<div class="summit-abstract" id="a-sel4-virtualization">{% include abstracts/2023/sel4-virtualization.html %}
 <!--a href="https://www.youtube.com/watch?" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a-->
 <br><a href="program#p-sel4-virtualization">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-building-commercial">{% include abstracts/building-commercial.html %}
+<div class="summit-abstract" id="a-building-commercial">{% include abstracts/2023/building-commercial.html %}
 <a href="https://youtu.be/TSYXw4DIGXw?si=BGeO-2LhY1lGREJr" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day3-03-sebranek.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-building-commercial">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-sel4-riscv">{% include abstracts/sel4-riscv.html %}
+<div class="summit-abstract" id="a-sel4-riscv">{% include abstracts/2023/sel4-riscv.html %}
 <a href="https://youtu.be/QSo03imeTx8?si=x2Qx7DRZb82xnJ7b" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day3-04-dematos.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>
 <br><a href="program#p-sel4-riscv">See this talk in the program</a></div>
 
-<div class="summit-abstract" id="a-trustworthy-measurements">{% include abstracts/trustworthy-measurements.html %}
+<div class="summit-abstract" id="a-trustworthy-measurements">{% include abstracts/2023/trustworthy-measurements.html %}
 <a href="https://youtu.be/lyTyJKugoqU?si=mbT_WOp2fGZsbL1h" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a>
 &nbsp;&nbsp;
 <a href="slides/day3-05-neises.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a>

--- a/Foundation/Summit/2023/program.html
+++ b/Foundation/Summit/2023/program.html
@@ -30,7 +30,7 @@ title: Summit program
     <td class="summit_chair">Darren Cofer &<br> Ihor Kuz</td>
     <td>Announcements</td>
     <td><em>Welcome</em></td>
-    <td><a href="https://youtu.be/xkb9yyxUK3M?si=4LLe7WYkdTVywcNv" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/pOucRQKcE5U?si=k6jaKvCFqRRYtZ6P" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-00-cofer.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-scoping-assurance">
@@ -53,7 +53,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-dynamic-sel4">Dynamic seL4 based systems: designing for verifiability<br><span class="summit-abstract-presenter">Matthew Brecknell</span></a>,
     <span class="summit-abstract-affiliation">Kry10</span>
     </td>
-    <td><a href="https://youtu.be/KTxz_UGGldA?si=ZmPV1JP5hmhaNZel" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/hHihCvB1cJI?si=3C1-F2wLJnEMHLDE" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-02-brecknell.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-formally-stepping">
@@ -62,7 +62,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-formally-stepping">Formally Stepping Into The Unverified World<br><span class="summit-abstract-presenter">Sandy Frost</span></a>,
     <span class="summit-abstract-affiliation">Los Alamos National Laboratory</span>
     </td>
-    <td><a href="https://youtu.be/tpooLn2aJJ4?si=v3HLLkrDN2ikdNa6" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/YnjpB5GlIsA?si=Nc8NuVBz_6oqi7Kp" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-03-frost.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr>
@@ -75,7 +75,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-reducing-reliance">Reducing the reliance on verification experts for seL4 proofs<br><span class="summit-abstract-presenter">Gerwin Klein</span></a>,
     <span class="summit-abstract-affiliation">Proofcraft</span>
     </td>
-    <td><a href="https://youtu.be/bxlE5AiQQXU?si=_n9CYMSfSGELmckg" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/XJTdhZqFONI?si=YNeFC0bfC_tMeH1N" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-04-klein.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-efficient-smp">
@@ -84,7 +84,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-efficient-smp">More multiprocessing on seL4: Are efficient SMP virtual machines possible on verifiable seL4 kernels?<br><span class="summit-abstract-presenter">Kent McLeod</span></a>,
     <span class="summit-abstract-affiliation">Kry10</span>
     </td>
-    <td><a href="https://youtu.be/PE7cLQ1OTqM?si=mm5mZHFut1EZNDWd" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/ePdaQDO5nhc?si=LMtGK8b2i7b91o0s" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-05-mcleod.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr>
@@ -97,7 +97,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-system-information">System Information Flow Analysis<br><span class="summit-abstract-presenter">Ihor Kuz</span></a>,
     <span class="summit-abstract-affiliation">Kry10</span>
     </td>
-    <td><a href="https://youtu.be/yk-8tb3ssHw?si=Z4QU0C0qlaSqLnut" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/u-yhdme-o0k?si=zbYHmq0QxzmmeZzt" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-06-kuz.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-advancements-virtualization">
@@ -106,7 +106,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-advancements-virtualization">Advancements for Virtualization Support in seL4:CAmkES and seL4cp<br><span class="summit-abstract-presenter">Markku Ahvenjärvi</span></a>,
     <span class="summit-abstract-affiliation">TII</span>
     </td>
-    <td><a href="https://youtu.be/GlHMxTiD3wo?si=WlS_9tPEi7BtUqdL" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/AsYB6yOAEYQ?si=jEewVOADm8NQv3bl" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-07-ahvenjärvi.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr>
@@ -119,7 +119,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-sel4-device">The seL4 Device Driver Framework<br><span class="summit-abstract-presenter">Lucy Parker</span></a>,
     <span class="summit-abstract-affiliation">UNSW</span>
     </td>
-    <td><a href="https://youtu.be/gDXsnBhNiQM?si=mgxC5xNNWiH0wabe" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/be0_PSW0b5M?si=t7dB73HMk8hR9mk0" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-08-parker.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-rd-update">
@@ -128,7 +128,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-rd-update">R&D Update from TS<br><span class="summit-abstract-presenter">Gernot Heiser</span></a>,
     <span class="summit-abstract-affiliation">UNSW</span>
     </td>
-    <td><a href="https://youtu.be/D6SRIUMAZAA?si=a9jKZXa97uDQgLJY" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/v16ycALKDLM?si=5eVX9qe2faJhDQyq" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-09-heiser.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr>
@@ -141,7 +141,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-sel4-experiences">seL4: Experiences, Improvements and Optimizations<br><span class="summit-abstract-presenter">Chris Guikema</span></a>,
     <span class="summit-abstract-affiliation">DornerWorks</span>
     </td>
-    <td><a href="https://youtu.be/bCRNTrZ9gx8?si=jA3paaa7efTwlG0M" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/SsEuhby_U6k?si=9dPxuHINTNOcLgFR" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-10-guikema.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-from-zero">
@@ -150,7 +150,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-from-zero">From Zero to a Native xHCl Driver<br><span class="summit-abstract-presenter">Josh Felmeden</span></a>,
     <span class="summit-abstract-affiliation">Capgemini Engineering</span>
     </td>
-    <td><a href="https://youtu.be/ih3oxRS8PAU?si=m-PtD8uXo8OOzx0-" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/Jsp2VMq3uDI?si=JucKo2C5ykhWaItl" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-11-felmeden.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-crashing-for">
@@ -159,7 +159,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-crashing-for">Crashing For Reliability<br><span class="summit-abstract-presenter">Ihor Kuz</span></a>,
     <span class="summit-abstract-affiliation">Kry10</span>
     </td>
-    <td><a href="https://youtu.be/9oxfqS6gUik?si=9ersOF3-REmUiR_k" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/jAzo4J9mrrE?si=h5slswaN53Ws4Ncf" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-12-kuz.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-sel4-foundation">
@@ -168,7 +168,7 @@ title: Summit program
     <td>seL4 Foundation update<br><span class="summit-abstract-presenter">June Andronick</span>,
     <span class="summit-abstract-affiliation">seL4 Foundation</span>
     </td>
-    <td><a href="https://youtu.be/eQNbS_p0DUY?si=Ald103RagN7dlNKs" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/PvzlLVP_dSk?si=-vdn7NdGrqEG0Rw9" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-12-andronick.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr>
@@ -181,7 +181,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-gold-kry10">Building a Platform for Critical Devices in the “Real World”<br><span class="summit-abstract-presenter">Boyd Multerer</span></a>,
     <span class="summit-abstract-affiliation">Kry10</span>
     </td>
-    <td><a href="https://youtu.be/kUWmockNkUY?si=22QhHV2woeubBgXj" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/1H5EQ4DrJeo?si=ZffQVqCmYRdZ4dfu" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day1-13-multerer.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr>
@@ -200,7 +200,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-cantripos">CantripOS: An OS for Ambient ML Applications<br><span class="summit-abstract-presenter">Sam Leffler</span></a>,
     <span class="summit-abstract-affiliation">Google</span>
     </td>
-    <td><a href="https://youtu.be/yITE9AvlohY?si=zHtRHuyqaYdk_yCj" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/-3SCCx-b61k?si=IpAa7ZHfBQf8Wd9l" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-01-leffler.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-announcements">
@@ -209,7 +209,7 @@ title: Summit program
     <td><br><span class="summit-abstract-presenter"></span>
     <span class="summit-abstract-affiliation"></span>
     </td>
-    <td><a href="https://youtu.be/_3fV1dteao8?si=dSOW9x_7vUvLHOb1" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/vUBmP6337vY?si=BVsTDyTkVjB-Wu5I" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td></td>
   </tr>
   <tr>
@@ -222,7 +222,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-magnetite">Magnetite: Rust-Based OS Services for seL4<br><span class="summit-abstract-presenter">Juliana Furgala</span></a>,
     <span class="summit-abstract-affiliation">MIT Lincoln Laboratory</span>
     </td>
-    <td><a href="https://youtu.be/O66mgVMAA6E?si=Me6zb6t7DqCi57On" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/UFF93HcQfEc?si=MrX9dEbI3b_CAamZ" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-02-furgala.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-showcase-microkernel">
@@ -231,7 +231,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-showcase-microkernel">Showcase: Microkernel OS, TPMs, and WASM in Ilo T Environments<br><span class="summit-abstract-presenter">Sid Hussmann</span></a>,
     <span class="summit-abstract-affiliation">Gapfruit</span>
     </td>
-    <td><a href="https://youtu.be/Kp-PsRZbbCc?si=_jYcxJgbgoLY3Hsr" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/R9zRyYVReKU?si=Jj-BjHhlqIQbCjob" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-03-hussman.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr>
@@ -244,7 +244,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-rust-support">Rust support in seL4 userspace: update and roadmap<br><span class="summit-abstract-presenter">Nick Spinale</span></a>,
     <span class="summit-abstract-affiliation">Colias Group</span>
     </td>
-    <td><a href="https://youtu.be/J17lC124_9s?si=m0QguvsgDXOTlrtz" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/jR2i4Y2Aq3o?si=rJSRRTD7Y-3Z6lUu" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-04-spinale.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-sel4-microkit">
@@ -253,7 +253,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-sel4-microkit">The seL4 Microkit<br><span class="summit-abstract-presenter">Ivan Velickovic</span></a>,
     <span class="summit-abstract-affiliation">UNSW</span>
     </td>
-    <td><a href="https://youtu.be/QWMyvFuJ-WQ?si=aN9vwOjgYmNsJ37w" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/1Y6uE3eZWKQ?si=9fIcnBFUlji0EOAj" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-05-velickovic.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr>
@@ -266,7 +266,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-leveraging-rust">Leveraging Rust for Core Platform<br><span class="summit-abstract-presenter">Ben Hamlin</span></a>,
     <span class="summit-abstract-affiliation">Galois</span>
     </td>
-    <td><a href="https://youtu.be/TeF0f0YcDOw?si=eCZA1ryWFpBZi5UR" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/JmqSfTEg0u8?si=pPKmIWJ4_PrHxvfk" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-06-hamlin.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-panel">
@@ -280,7 +280,7 @@ title: Summit program
     <span class="summit-abstract-presenter-bold">Juliana Furgala</span>,
     <span class="summit-abstract-affiliation">MIT Lincoln Laboratory</span></a>
     </td>
-    <td><a href="https://youtu.be/e7-laSU2NS0?si=zP-36-6VWKaIM0xP" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/PynVzpXRW-o?si=JR_9nGM3fwILHnJc" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td></td>
   </tr>
   <tr>
@@ -293,7 +293,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-sel4-vmm">seL4 VMM on the RISC-V Rocket Chip<br><span class="summit-abstract-presenter">Robbie VanVossen</span></a>,
     <span class="summit-abstract-affiliation">DornerWorks</span>
     </td>
-    <td><a href="https://youtu.be/YtTM0jn4iN0?si=gG1o6Ygq6vYjWbkF" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/a-JLqYVINxo?si=EjKQHSYPmGrlgLna" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-08-vanvossen.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-sel4-arm">
@@ -302,7 +302,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-sel4-arm">seL4 on Arm Morello<br><span class="summit-abstract-presenter">Martin Atkins</span></a>,
     <span class="summit-abstract-affiliation">Mission Critical Applications</span>
     </td>
-    <td><a href="https://youtu.be/YeBqmRWQWrI?si=WNTDVL0iIODbOtL3" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/VcufX8hZ5-o?si=zNc0rSodvxrm5DF8" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-09-atkins.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr>
@@ -315,7 +315,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-incremental-assurance">Incremental assurance for a Rust network stack<br><span class="summit-abstract-presenter">Michal Podhradsky</span></a>,
     <span class="summit-abstract-affiliation">Galois</span>
     </td>
-    <td><a href="https://youtu.be/uLA6bbDzGyI?si=e9G9h2eZ_4oVjxo_" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/c7UC2Rgj3n4?si=XCFZwqwZbTeERon1" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-10-podhradsky.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-toward-verified">
@@ -324,7 +324,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-toward-verified">Toward a Verified, Minimal IPv6 Network Stack Implementation<br><span class="summit-abstract-presenter">Wyeth Greenlaw Rollins</span></a>,
     <span class="summit-abstract-affiliation">Lewis & Clark College</span>
     </td>
-    <td><a href="https://youtu.be/rkuqmizZjbw?si=ojlp7FRRoduiOXIQ" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/wjrA0HlW9JQ?si=O-s5cyDWcgz_LxTY" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-11-rollins.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-iommu">
@@ -333,7 +333,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-iommu">IOMMU (take the ARM SMMUv3 for instance) solution for seL4<br><span class="summit-abstract-presenter">Lei Mao</span></a>,
     <span class="summit-abstract-affiliation">Horizon Robotics</span>
     </td>
-    <td><a href="https://youtu.be/83NvRf4zsJQ?si=FohEFUf2QCvGPiWk" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/6knMCkB-Qvw?si=sd1etRZ3Y4Y_Z0Kc" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-12-mao.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-gold-nio">
@@ -343,7 +343,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-gold-nio">OS for Software Defined Vehicle<br><span class="summit-abstract-presenter">Qiyan Wang</span></a>,
     <span class="summit-abstract-affiliation">NIO</span>
     </td>
-    <td><a href="https://youtu.be/HfvX2VbWp6c?si=TpCsq8GtYme0SY12" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/W_Y3M6s4E9w?si=OHlpA1kppVWKtbyk" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-13-wang.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-gold-tii">
@@ -352,7 +352,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-gold-tii">Secure Systems in Focus: Challenges, Solutions, and Future Directions<br><span class="summit-abstract-presenter">Everton de Matos</span></a>,
     <span class="summit-abstract-affiliation">TII</span>
     </td>
-    <td><a href="https://youtu.be/NrtkpOHv8-k?si=ig8c4umBXrd5Y1cI" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/MX_svP-Sopk?si=L7DBrBEMd7eIxNYs" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day2-14-dematos.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr>
@@ -377,7 +377,7 @@ title: Summit program
     <span class="summit-abstract-presenter">Kent McLeod</span>,
     <span class="summit-abstract-affiliation">Kry10</span></a>
     </td>
-    <td><a href="https://youtu.be/Z8TK83qx0NY?si=Yy8GpNi1KHEWYbwl" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/ZHLePzGa4vs?si=2Jk9djA0IbBaO81G" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td></td>
   </tr>
   <tr id="p-sel4-virtualization">
@@ -399,7 +399,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-building-commercial">Building a Commercial Virtualized Mobile Device with seL4 - Part 2<br><span class="summit-abstract-presenter">Jason Sebranek</span></a>,
     <span class="summit-abstract-affiliation">Cog Systems</span>
     </td>
-    <td><a href="https://youtu.be/pC2KdpTPstI?si=u9_u0RJ0xnyrfM14" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/TSYXw4DIGXw?si=BGeO-2LhY1lGREJr" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day3-03-sebranek.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-sel4-riscv">
@@ -408,7 +408,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-sel4-riscv">seL4 on RISC-V: Building a Trusted Execution Environment<br><span class="summit-abstract-presenter">Everton de Matos</span></a>,
     <span class="summit-abstract-affiliation">TII</span>
     </td>
-    <td><a href="https://youtu.be/7L-hLbxCkCc?si=52JqDj12s7tLqKa0" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/QSo03imeTx8?si=x2Qx7DRZb82xnJ7b" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day3-04-dematos.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr id="p-trustworthy-measurements">
@@ -417,7 +417,7 @@ title: Summit program
     <td><a class="summit-abstract-link" href="abstracts2023#a-trustworthy-measurements">Trustworthy Measurements of a Linux Kernel and Layered Attestation via the seL4<br><span class="summit-abstract-presenter">Michael Neises</span></a>,
     <span class="summit-abstract-affiliation">University of Kansas</span>
     </td>
-    <td><a href="https://youtu.be/tGRQFvVnmVU?si=Mhz7ofjOE7DDCZcR" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
+    <td><a href="https://youtu.be/lyTyJKugoqU?si=mbT_WOp2fGZsbL1h" target="_blank"><img src="../../../images/icons/youtube_nobckgnd.svg" class="youtube_icon" alt="YouTube icon"></a></td>
     <td><a href="slides/day3-05-neises.pdf"><img src="../../../images/icons/slides.svg" alt="slides icon"></a></td>
   </tr>
   <tr>


### PR DESCRIPTION
Fix YouTube URLs for summit 2023 videos, which were reloaded to YouTube to add sponsor logos.