### PR TITLE
make template URLs relative

### DIFF
--- a/_includes/crumb.html
+++ b/_includes/crumb.html
@@ -28,4 +28,4 @@
 {%-			break -%}
 {%-		endif -%}
 {%-	endfor -%}
-<li><a href="{{ curl }}">{{ cname | split: "." | first }}</a></li>
+<li><a href="{{ curl | relative_url }}">{{ cname | split: "." | first }}</a></li>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -15,9 +15,9 @@
 {%-				assign active = 'active' -%}
 {%-			endif -%}
 		<li class="dropdown {{ active }}"><a class="dropdown-toggle" data-toggle="dropdown" href="
-		{{- url }}">{{ name }} <span class="caret"></span></a>
+		{{- url | relative_url }}">{{ name }} <span class="caret"></span></a>
 {%-		else %}
-		<li class="{{ active }}"><a href="{{ url }}">{{ name }}</a>
+		<li class="{{ active }}"><a href="{{ url | relative_url }}">{{ name }}</a>
 {%-		endif -%}
 {%-		if submenu %}
 		<ul class="dropdown-menu">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,28 +10,28 @@
     <title>{{ page.title }} | {{ site.title }}</title>
     <meta name="author" content="seL4 Foundation" />
     <link rel="canonical" href="{{ site.url }}{{ page.url | replace:'index.html',''}}">
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/sel4.css" rel="stylesheet">
+    <link href={{ "/css/bootstrap.min.css" | relative_url }} rel="stylesheet">
+    <link href={{ "/css/sel4.css" | relative_url }} rel="stylesheet">
 
-    <link rel="apple-touch-icon" sizes="57x57" href="/images/icons/apple-touch-icon-57x57.png" />
-    <link rel="apple-touch-icon" sizes="114x114" href="/images/icons/apple-touch-icon-114x114.png" />
-    <link rel="apple-touch-icon" sizes="72x72" href="/images/icons/apple-touch-icon-72x72.png" />
-    <link rel="apple-touch-icon" sizes="144x144" href="/images/icons/apple-touch-icon-144x144.png" />
-    <link rel="apple-touch-icon" sizes="60x60" href="/images/icons/apple-touch-icon-60x60.png" />
-    <link rel="apple-touch-icon" sizes="120x120" href="/images/icons/apple-touch-icon-120x120.png" />
-    <link rel="apple-touch-icon" sizes="76x76" href="/images/icons/apple-touch-icon-76x76.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="/images/icons/apple-touch-icon-152x152.png" />
-    <link rel="icon" type="image/png" href="/images/icons/favicon-96x96.png" sizes="96x96" />
-    <link rel="icon" type="image/png" href="/images/icons/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/images/icons/favicon-16x16.png" sizes="16x16" />
+    <link rel="apple-touch-icon" sizes="57x57" href={{ "/images/icons/apple-touch-icon-57x57.png" | relative_url }} />
+    <link rel="apple-touch-icon" sizes="114x114" href={{ "/images/icons/apple-touch-icon-114x114.png" | relative_url }} />
+    <link rel="apple-touch-icon" sizes="72x72" href={{ "/images/icons/apple-touch-icon-72x72.png" | relative_url }} />
+    <link rel="apple-touch-icon" sizes="144x144" href={{ "/images/icons/apple-touch-icon-144x144.png" | relative_url }} />
+    <link rel="apple-touch-icon" sizes="60x60" href={{ "/images/icons/apple-touch-icon-60x60.png" | relative_url }} />
+    <link rel="apple-touch-icon" sizes="120x120" href={{ "/images/icons/apple-touch-icon-120x120.png" | relative_url }} />
+    <link rel="apple-touch-icon" sizes="76x76" href={{ "/images/icons/apple-touch-icon-76x76.png" | relative_url }} />
+    <link rel="apple-touch-icon" sizes="152x152" href={{ "/images/icons/apple-touch-icon-152x152.png" | relative_url }} />
+    <link rel="icon" type="image/png" href={{ "/images/icons/favicon-96x96.png" | relative_url }} sizes="96x96" />
+    <link rel="icon" type="image/png" href={{ "/images/icons/favicon-32x32.png" | relative_url }} sizes="32x32" />
+    <link rel="icon" type="image/png" href={{ "/images/icons/favicon-16x16.png" | relative_url }} sizes="16x16" />
     <meta name="application-name" content="&nbsp;"/>
     <meta name="msapplication-TileColor" content="#FFFFFF" />
-    <meta name="msapplication-TileImage" content="/images/icons/mstile-144x144.png" />
-    <meta name="msapplication-square70x70logo" content="/images/icons/mstile-70x70.png" />
-    <meta name="msapplication-square150x150logo" content="/images/icons/mstile-150x150.png" />
-    <meta name="msapplication-wide310x150logo" content="/images/icons/mstile-310x150.png" />
-    <meta name="msapplication-square310x310logo" content="/images/icons/mstile-310x310.png" />
-    <link rel="shortcut icon" href="/images/icons/favicon.ico" />
+    <meta name="msapplication-TileImage" content={{ "/images/icons/mstile-144x144.png" | relative_url }} />
+    <meta name="msapplication-square70x70logo" content={{ "/images/icons/mstile-70x70.png" | relative_url }} />
+    <meta name="msapplication-square150x150logo" content={{ "/images/icons/mstile-150x150.png" | relative_url }} />
+    <meta name="msapplication-wide310x150logo" content={{ "/images/icons/mstile-310x150.png" | relative_url }} />
+    <meta name="msapplication-square310x310logo" content={{ "/images/icons/mstile-310x310.png" | relative_url }} />
+    <link rel="shortcut icon" href={{ "/images/icons/favicon.ico" | relative_url }} />
 {% if jekyll.environment == "production" %}
     <script defer data-domain="sel4.systems" src="https://analytics.sel4.systems/js/script.js"></script>
 {% endif %}
@@ -57,15 +57,15 @@
 {%- endif -%}
   </div>
 {% if page.url contains "/Foundation/Summit" %}
-  <a href='/Foundation/Summit'><img style="width:20%; padding-top:5px; vertical-align:top;float:right; margin:10px;"
-                     src='/images/sel4-summit-logo.svg' alt='seL4 summit logo' /></a>
+  <a href={{ '/Foundation/Summit' | relative_url }}><img style="width:20%; padding-top:5px; vertical-align:top;float:right; margin:10px;"
+                     src={{ '/images/sel4-summit-logo.svg' | relative_url }} alt='seL4 summit logo' /></a>
 {% elsif page.url contains "/Foundation" %}
-    <a href='/'><img style="width:20%; padding-top:5px; vertical-align:top;float:right; margin:10px;"
-                     src='/images/sel4-foundation-logo.svg' alt='seL4 foundation logo' />
+    <a href={{ '/' | relative_url }}><img style="width:20%; padding-top:5px; vertical-align:top;float:right; margin:10px;"
+                     src={{ '/images/sel4-foundation-logo.svg' | relative_url }} alt='seL4 foundation logo' />
     </a>
 {% else %}
-    <a href='/'><img style="width:20%; margin-top:20px; vertical-align:top;float:right; margin:10px;"
-                     src='/images/logo-text-white.svg' alt='seL4' /></a>
+    <a href={{ '/' | relative_url }}><img style="width:20%; margin-top:20px; vertical-align:top;float:right; margin:10px;"
+                     src={{ '/images/logo-text-white.svg' | relative_url }} alt='seL4' /></a>
 {% endif %}
 {{ content }}
 <div class="divider"></div>
@@ -75,9 +75,9 @@
   <div class="container">
     <!-- for mobile screens -->
     <div class="text-center visible-xs">
-    <a href="https://fosstodon.org/@sel4"><img style="height:36px; padding-right:5px; padding-top:2px; padding-bottom:2px;" src="/images/icons/mastodon.svg" alt="mastodon icon"></a>
-      <a href="https://www.youtube.com/@seL4"><img style="height:36px; padding-top:2px; padding-bottom:2px;" src="/images/icons/youtube.svg" alt="youtube icon"></a>
-      <a href="https://www.linkedin.com/company/sel4"><img style="height:36px; padding-left:5px; padding-top:2px; padding-bottom:2px;" src="/images/icons/linkedin.svg" alt="linkedin icon"></a>
+    <a href="https://fosstodon.org/@sel4"><img style="height:36px; padding-right:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/mastodon.svg" | relative_url }} alt="mastodon icon"></a>
+      <a href="https://www.youtube.com/@seL4"><img style="height:36px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/youtube.svg" | relative_url }} alt="youtube icon"></a>
+      <a href="https://www.linkedin.com/company/sel4"><img style="height:36px; padding-left:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/linkedin.svg" | relative_url }} alt="linkedin icon"></a>
       <br>
       <br>
     Copyright &copy; 2024 seL4 Project a Series of LF Projects, LLC.<br/>
@@ -86,7 +86,7 @@
       and other applicable policies, as well as terms and conditions
       governing this web site, please see
       <a href="http://www.lfprojects.org/">www.lfprojects.org</a>
-      and the <a href="/Foundation/Trademark/">trademark guidelines</a>.
+      and the <a href={{ "/Foundation/Trademark/" | relative_url }}>trademark guidelines</a>.
     </div>
     <div class="row">
       <!-- for screens larger than mobiles -->
@@ -97,12 +97,12 @@
         and other applicable policies, as well as terms and conditions
         governing this web site, please see
         <a href="http://www.lfprojects.org/">www.lfprojects.org</a>
-        and the <a href="/Foundation/Trademark/">trademark guidelines</a>.
+        and the <a href={{ "/Foundation/Trademark/" | relative_url }}>trademark guidelines</a>.
       </div>
       <div class="col-xs-6 text-right hidden-xs">
-        <a href="https://fosstodon.org/@sel4"><img style="height:36px; padding-right:5px; padding-top:2px; padding-bottom:2px;" src="/images/icons/mastodon.svg" alt="mastodon icon"></a>
-        <a href="https://www.youtube.com/@seL4"><img style="height:36px; padding-top:2px; padding-bottom:2px;" src="/images/icons/youtube.svg" alt="youtube icon"></a>
-        <a href="https://www.linkedin.com/company/sel4"><img style="height:36px; padding-left:5px; padding-top:2px; padding-bottom:2px;" src="/images/icons/linkedin.svg" alt="linkedin icon"></a>
+        <a href="https://fosstodon.org/@sel4"><img style="height:36px; padding-right:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/mastodon.svg" | relative_url }} alt="mastodon icon"></a>
+        <a href="https://www.youtube.com/@seL4"><img style="height:36px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/youtube.svg" | relative_url }} alt="youtube icon"></a>
+        <a href="https://www.linkedin.com/company/sel4"><img style="height:36px; padding-left:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/linkedin.svg" | relative_url }} alt="linkedin icon"></a>
       </div>
     </div>
   </div>
@@ -111,8 +111,8 @@
 {% endif %}
 </footer> <!-- footer -->
 <!-- wrapper -->
-<script src="/js/jquery.min.js"></script>
-<script src="/js/bootstrap.min.js"></script>
+<script src={{ "/js/jquery.min.js" | relative_url }}></script>
+<script src={{ "/js/bootstrap.min.js" | relative_url }}></script>
 </div><!--page-container-->
 </body>
 </html>

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -9,13 +9,14 @@ layout: default
  <div class="col">
   <h1>
     News about
-    <a href="/">seL4</a>
+    <a href={{ "/" | relative_url }}>seL4</a>
     and the
-    <a href="/Foundation">seL4 Foundation</a>
+    <a href={{ "/Foundation" | relative_url }}>seL4 Foundation</a>
   </h1>
  </div>
  <div class="col">
-Older News:  {% for i in (2020..newest_year) -%}<a href="/news/{{ i }}">{{ i }}</a> {% endfor %}
+{% assign url = "/news/" | relative_url -%}
+Older News:  {% for i in (2020..newest_year) -%}<a href="{{ url }}{{ i }}">{{ i }}</a> {% endfor %}
  </div>
 </div>
 {{ content }}


### PR DESCRIPTION
Relative in jekyll terminology only means relative to the root of the site, not relative to the current page, but the root can be set via base_url.

This is a first step towards making previews work again and should not have any effect on the generated html yet. The only difference should be that if you now set `base_url`, the links generated from templates (menu, breadcrumbs, css, etc) will point to the right location.