### PR TITLE
make all links document-relative

### DIFF
--- a/About/index.html
+++ b/About/index.html
@@ -102,6 +102,6 @@ redirect_from:
 
 <p>
   More on TS ongoing and future <a
-  href="/Info/more-research.html">research</a> about seL4 and trustworthy
+  href="../Info/more-research.html">research</a> about seL4 and trustworthy
   systems.
 </p>

--- a/Contribute/index.html
+++ b/Contribute/index.html
@@ -30,7 +30,7 @@ redirect_from: /Contribute/home.pml
 
 <p>As a result, our infrastructure for proof contributions is not as mature as that for code contributions.</p>
 
-<p>We are aiming to provide more resources in the next few months. In the meantime, if you are interested in contributing to the seL4 proofs, please review the <a href="https://github.com/seL4/l4v/">actual proofs</a> and the tools and techniques used for the proofs. Then <a href="/contact/">contact us</a> to discuss ideas, plans, and options about your contributions.</p>
+<p>We are aiming to provide more resources in the next few months. In the meantime, if you are interested in contributing to the seL4 proofs, please review the <a href="https://github.com/seL4/l4v/">actual proofs</a> and the tools and techniques used for the proofs. Then <a href="../contact/">contact us</a> to discuss ideas, plans, and options about your contributions.</p>
 
 <p>To get started, you will have to be familiar with the <a href="https://isabelle.in.tum.de/">Isabelle theorem prover</a>. Some learning resources for it are described in <a href="http://proofcraft.org/blog/proof-engineer-reading.html">this blog post</a>.
 
@@ -42,6 +42,6 @@ redirect_from: /Contribute/home.pml
 
 <h2 id="community-support-contributions">Community Support Contributions</h2>
 
-<p>The <a href="/contact/">seL4 discussion and support platforms</a> are open to the community and we invite community participation, not only in asking questions, but also in answering questions and providing help.</p>
+<p>The <a href="../contact/">seL4 discussion and support platforms</a> are open to the community and we invite community participation, not only in asking questions, but also in answering questions and providing help.</p>
 
 <p>Please see our <a href="https://docs.sel4.systems/processes/conduct.html">Community Guidelines</a> on the docsite.</p>

--- a/Foundation/Jobs/index.html
+++ b/Foundation/Jobs/index.html
@@ -5,7 +5,7 @@ title: Jobs About seL4
 redirect_from: /Foundation/Jobs/home.pml
 ---
 <h1>
-  Jobs in the <a href="/">seL4</a> ecosystem.
+  Jobs in the <a href={{ "/" | relative_url }}>seL4</a> ecosystem.
 </h1>
 
 <p>
@@ -56,7 +56,7 @@ explicit description of how the job will be linked to seL4.
 </div>
 <div>
  <p>
-   <img src="/images/seL4.svg"
+   <img src="../../images/seL4.svg"
    style="width:30%; padding-left:1em; float:right"
    alt="seL4">
  </p>

--- a/Foundation/Services/cog.html
+++ b/Foundation/Services/cog.html
@@ -16,7 +16,7 @@ An Endorsed Service Provider for seL4-based systems
       <tr>
       <td style="padding:15px">
 	<a href="https://cog.systems">
-	  <img src="/Foundation/Membership/LOGOS/Cog.jpg" style="width: 200px" alt="Cog Systems Inc">
+	  <img src="../Membership/LOGOS/Cog.jpg" style="width: 200px" alt="Cog Systems Inc">
 	</a>
       </td>
       <td>

--- a/Foundation/Services/dornerworks.html
+++ b/Foundation/Services/dornerworks.html
@@ -15,7 +15,7 @@ An Endorsed Service Provider for seL4-based systems
     <tr>
       <td style="padding:15px">
 	<a href="https://dornerworks.com">
-	  <img src="/Foundation/Membership/LOGOS/DornerWorks.svg" style="width: 200px" alt="DornerWorks Ltd">
+	  <img src="../Membership/LOGOS/DornerWorks.svg" style="width: 200px" alt="DornerWorks Ltd">
 	</a>
       </td>
       <td>

--- a/Foundation/Services/hc.html
+++ b/Foundation/Services/hc.html
@@ -16,7 +16,7 @@ An Endorsed Service Provider for seL4-based systems
     <tr>
       <td style="padding:15px">
         <a href="http://hensoldt-cyber.com/">
-          <img src="/Foundation/Membership/LOGOS/HENSOLDT_Cyber.svg" style="width: 200px" alt="HENSOLDT Cyber">
+          <img src="../Membership/LOGOS/HENSOLDT_Cyber.svg" style="width: 200px" alt="HENSOLDT Cyber">
 	</a>
       </td>
       <td>

--- a/Foundation/Services/index.html
+++ b/Foundation/Services/index.html
@@ -27,7 +27,7 @@ redirect_from: /Foundation/Services/home.pml
     <tr>
       <td>
 	<a href="https://dornerworks.com">
-	  <img src="/Foundation/Membership/LOGOS/DornerWorks.svg" style="width: 200px" alt="DornerWorks Ltd">
+	  <img src="../Membership/LOGOS/DornerWorks.svg" style="width: 200px" alt="DornerWorks Ltd">
 	</a>
       </td>
       <td>
@@ -52,7 +52,7 @@ redirect_from: /Foundation/Services/home.pml
     <tr>
       <td>
 	<a href="https://brkawy.com">
-	  <img src="/Foundation/Membership/LOGOS/Brkawy.png" style="width: 200px" alt="Breakaway Consulting">
+	  <img src="../Membership/LOGOS/Brkawy.png" style="width: 200px" alt="Breakaway Consulting">
 	</a>
       </td>
       <td>
@@ -79,7 +79,7 @@ redirect_from: /Foundation/Services/home.pml
     <tr>
       <td>
 	<a href="https://cog.systems">
-	  <img src="/Foundation/Membership/LOGOS/Cog.jpg" style="width: 200px" alt="Cog Systems Inc">
+	  <img src="../Membership/LOGOS/Cog.jpg" style="width: 200px" alt="Cog Systems Inc">
 	</a>
       </td>
       <td>
@@ -102,7 +102,7 @@ redirect_from: /Foundation/Services/home.pml
     <tr>
       <td>
         <a href="http://unsw.edu.au/">
-          <img src="/Foundation/Membership/LOGOS/UNSW.svg"
+          <img src="../Membership/LOGOS/UNSW.svg"
           style="width: 200px" alt="UNSW Sydney">
 	</a>
       </td>
@@ -133,7 +133,7 @@ redirect_from: /Foundation/Services/home.pml
     <tr>
       <td>
         <a href="https://proofcraft.systems">
-        <img src="/Foundation/Membership/LOGOS/proofcraft.svg"
+        <img src="../Membership/LOGOS/proofcraft.svg"
 	  style="width: 200px" alt="Proofcraft">
 	</a>
       </td>
@@ -177,7 +177,7 @@ redirect_from: /Foundation/Services/home.pml
     <tr>
       <td>
         <a href="https://www.kry10.com/">
-        <img src="/Foundation/Membership/LOGOS/Kry10.svg"
+        <img src="../Membership/LOGOS/Kry10.svg"
 	  style="width: 200px" alt="Kry10">
 	</a>
       </td>
@@ -218,7 +218,7 @@ redirect_from: /Foundation/Services/home.pml
     <tr>
       <td style="padding:15px">
 	<a href="https://unsw.edu.au">
-	  <img src="/Foundation/Membership/LOGOS/UNSW.svg"
+	  <img src="../Membership/LOGOS/UNSW.svg"
 	  style="width: 200px" alt="UNSW Sydney">
 	</a>
       </td>
@@ -261,7 +261,7 @@ redirect_from: /Foundation/Services/home.pml
     <tr>
       <td style="padding:15px">
         <a href="http://hensoldt-cyber.com/">
-          <img src="/Foundation/Membership/LOGOS/HENSOLDT_Cyber.svg"
+          <img src="../Membership/LOGOS/HENSOLDT_Cyber.svg"
 	  style="width: 200px" alt="HENSOLDT Cyber">
 	</a>
       </td>
@@ -293,7 +293,7 @@ redirect_from: /Foundation/Services/home.pml
     <tr>
       <td style="padding:15px">
         <a href="http://hensoldt-cyber.com/">
-          <img src="/Foundation/Membership/LOGOS/HENSOLDT_Cyber.svg"
+          <img src="../Membership/LOGOS/HENSOLDT_Cyber.svg"
 	  style="width: 200px" alt="HENSOLDT Cyber">
 	</a>
       </td>

--- a/Foundation/Summit/2023/index.html
+++ b/Foundation/Summit/2023/index.html
@@ -108,7 +108,7 @@ Minneapolis, USA
     <div class="speaker">
       <div class="speaker_pic">
         <a href="https://www.ncsc.gov.uk/">
-          <img src="/Foundation/Membership/LOGOS/NCSC.png" style="width: 200px" alt="NCSC logo" />
+          <img src="../../Membership/LOGOS/NCSC.png" style="width: 200px" alt="NCSC logo" />
         </a>
       </div>
       <div class="speaker_title" style="text-align:center">
@@ -147,7 +147,7 @@ Minneapolis, USA
   </h3>
   <p>
     <p>
-    We were very fortunate to welcome five industry leaders to participate at the <a href="/Foundation/Summit/2023">seL4 Summit 2023</a>, in a session <a href="https://events.linuxfoundation.org/sel4-summit/program/schedule/">OS on seL4: so many options!</a>. Gapfruit, Kry10, Magnetite (MIT), and UNSW presented their views on the priorities and vision for their OS on seL4. The panel was moderated by Todd Carpenter from Galois.
+    We were very fortunate to welcome five industry leaders to participate at the <a href="./">seL4 Summit 2023</a>, in a session <a href="https://events.linuxfoundation.org/sel4-summit/program/schedule/">OS on seL4: so many options!</a>. Gapfruit, Kry10, Magnetite (MIT), and UNSW presented their views on the priorities and vision for their OS on seL4. The panel was moderated by Todd Carpenter from Galois.
   </p>
 
   <div class="speakers_grid">

--- a/Foundation/Trademark/logo.html
+++ b/Foundation/Trademark/logo.html
@@ -16,7 +16,7 @@ title: seL4 Logo Pack
   <div class="homepage_item" style="grid-template-rows: 200px 10px 20px;">
     <a class="divLink" href="seL4-logo.zip"></a>
     <div class="hp_pic">
-      <img src="/images/seL4.svg" style="width:400px;" alt="seL4 logo" />
+      <img src="../../images/seL4.svg" style="width:400px;" alt="seL4 logo" />
     </div>
     <div class="hp_title">
       Download the seL4 Logo Pack

--- a/Foundation/index.html
+++ b/Foundation/index.html
@@ -28,8 +28,8 @@ redirect_from: /Foundation/home.pml
       <a title="Join" href="Join">HERE!</a></span>
   </p>
 
-  <a href="/images/mosaic-high.jpg">
-    <img src="/images/mosaic.jpg" style="width:300px; padding-left:10px; float:right;"
+  <a href="../images/mosaic-high.jpg">
+    <img src="../images/mosaic.jpg" style="width:300px; padding-left:10px; float:right;"
       alt="seL4 foundation launch"
 	   /></a>
   <p>

--- a/Info/index.html
+++ b/Info/index.html
@@ -13,7 +13,7 @@ redirect_from: /Info/home.pml
   <div class="homepage_item">
     <a class="divLink" href="more-research.html"></a>
     <div class="hp_pic">
-      <img src="/images/call-graph.png" style="width:200px;" alt="seL4 call graph" />
+      <img src="../images/call-graph.png" style="width:200px;" alt="seL4 call graph" />
     </div>
     <div class="hp_title">
       Research
@@ -27,7 +27,7 @@ redirect_from: /Info/home.pml
   <div class="homepage_item">
     <a class="divLink" href="https://docs.sel4.systems/projects/roadmap.html"></a>
     <div class="hp_pic">
-      <img src="/images/roadmap.jpg" style="width:200px;" alt="Roadmap" />
+      <img src="../images/roadmap.jpg" style="width:200px;" alt="Roadmap" />
     </div>
     <div class="hp_title">
       Roadmap
@@ -40,7 +40,7 @@ redirect_from: /Info/home.pml
   <div class="homepage_item">
     <a class="divLink" href="https://docs.sel4.systems/projects/sel4/frequently-asked-questions.html"></a>
     <div class="hp_pic">
-      <img src="/images/faq.svg" style="width:200px;" alt="FAQ" />
+      <img src="../images/faq.svg" style="width:200px;" alt="FAQ" />
     </div>
     <div class="hp_title">
     FAQ

--- a/Use/index.html
+++ b/Use/index.html
@@ -11,7 +11,7 @@ redirect_from: /Use/home.pml
     This page discusses the issues a business will need to consider for a <b>“transition to seL4”</b>, whether creating a
     new product or upgrading an existing product.</p>
    <p>Ultimately,
-    the best approach is to <a href="/contact/">contact us</a>
+    the best approach is to <a href="../contact/">contact us</a>
     to discuss your needs and aims, but
     brainstorming through the considerations described below is a good
     first step in any case. This will also give you an idea of the
@@ -26,13 +26,13 @@ redirect_from: /Use/home.pml
   <p>
     You might also have questions on the <b> licence </b> and its implications.
     For this, read <a href="https://microkerneldude.wordpress.com/2019/12/09/what-does-sel4s-license-imply/">Gernot’s licensing blog</a> and
-    <a href="/contact/">contact us</a> if you have
+    <a href="../contact/">contact us</a> if you have
     any questions!
   </p>
   <p>Now to the considerations.</p>
   <ol>
     <li> <b>The aim: Security through isolation</b>.
-      <img src="/images/trusted.svg" style="width:300px; float:right;" alt="seL4 system"/>
+      <img src="../images/trusted.svg" style="width:300px; float:right;" alt="seL4 system"/>
       <p>The first step is to identify the security and
       safety requirements of your system (what are the assets that need protecting), and the threat
       model (what are the attacks or failures that threaten those assets).</p>
@@ -59,7 +59,7 @@ redirect_from: /Use/home.pml
       <p>If the answer to some of these questions is &ldquo;no&rdquo;, you can
       check whether it’s on the <a href="https://docs.sel4.systems/projects/roadmap.html">roadmap</a>
       of seL4, and
-      <a href="/contact/">contact us</a> to
+      <a href="../contact/">contact us</a> to
       discuss extending seL4’s support.</p>
       <p>Keep in mind that even if a particular configuration is not (yet) verified, it will still be highly robust, owing to sharing the design and much of its code with verified configurations.</p>
 
@@ -68,8 +68,8 @@ redirect_from: /Use/home.pml
       remember that seL4 is just a microkernel, and will require a number of
       OS services to run. You can check the list of <a href="https://docs.sel4.systems/projects/available-user-components.html">available components</a>
       and if the ones you need are missing,
-      <a href="/contact/">contact us</a>, or better yet
-      <a href="/Contribute">contribute</a>.</p>
+      <a href="../contact/">contact us</a>, or better yet
+      <a href="../Contribute">contribute</a>.</p>
     </li>
     <li> <b>Gradually getting there: Incremental cyber retrofit</b>
 
@@ -84,7 +84,7 @@ redirect_from: /Use/home.pml
       <p>In subsequent steps this is repeated and refined until individual trusted components are placed into their own, isolated, sandboxes running
       natively on seL4.</p>
 
-      <img src="/images/retrofit.png" style="width:700px;" alt="seL4 system"
+      <img src="../images/retrofit.png" style="width:700px;" alt="seL4 system"
 	   />
     </li>
   </ol>

--- a/index.html
+++ b/index.html
@@ -50,9 +50,9 @@ redirect_from: /home.pml
 
 <div class="homepage_grid">
   <div class="homepage_item">
-    <a class="divLink" href="/About/"></a>
+    <a class="divLink" href="About/"></a>
     <div class="hp_pic">
-      <img src="/images/seL4.svg" style="width:150px;height:58px;" alt="seL4" />
+      <img src="images/seL4.svg" style="width:150px;height:58px;" alt="seL4" />
     </div>
     <div class="hp_title">
       What is seL4?
@@ -63,9 +63,9 @@ redirect_from: /home.pml
   </div>
 
   <div class="homepage_item">
-    <a class="divLink" href="/Foundation"></a>
+    <a class="divLink" href="Foundation"></a>
     <div class="hp_pic">
-      <img src="/images/sel4-foundation-logo.svg" style="width:200px;height:87px;" alt="seL4 Foundation" />
+      <img src="images/sel4-foundation-logo.svg" style="width:200px;height:87px;" alt="seL4 Foundation" />
     </div>
     <div class="hp_title">
       seL4 Foundation
@@ -76,9 +76,9 @@ redirect_from: /home.pml
   </div>
 
   <div class="homepage_item">
-    <a class="divLink" href="/contact"></a>
+    <a class="divLink" href="contact"></a>
     <div class="hp_pic">
-      <img src="/images/contacts.png" style="width:160px;height:98px;" alt="Contacts" />
+      <img src="images/contacts.png" style="width:160px;height:98px;" alt="Contacts" />
     </div>
     <div class="hp_title">
       Stay in touch
@@ -89,9 +89,9 @@ redirect_from: /home.pml
   </div>
 
   <div class="homepage_item">
-    <a class="divLink" href="/Foundation/Services/"></a>
+    <a class="divLink" href="Foundation/Services/"></a>
     <div class="hp_pic">
-      <img src="/images/services.png" style="width:110px;height:110px" alt="Contribute" />
+      <img src="images/services.png" style="width:110px;height:110px" alt="Contribute" />
     </div>
     <div class="hp_title">
       Commercial Support
@@ -102,9 +102,9 @@ redirect_from: /home.pml
   </div>
 
   <div class="homepage_item">
-    <a class="divLink" href="/Use"></a>
+    <a class="divLink" href="Use"></a>
     <div class="hp_pic">
-      <img src="/images/sel4_quad_low.jpg" style="width:200px;height:68px;" alt="seL4 quadcopter" />
+      <img src="images/sel4_quad_low.jpg" style="width:200px;height:68px;" alt="seL4 quadcopter" />
     </div>
     <div class="hp_title">
       Use
@@ -116,9 +116,9 @@ redirect_from: /home.pml
 
 
   <div class="homepage_item">
-    <a class="divLink" href="/Learn"></a>
+    <a class="divLink" href="Learn"></a>
     <div class="hp_pic">
-      <img src="/images/learning.jpg" style="width:200px;height:112px;" alt="Learn" />
+      <img src="images/learning.jpg" style="width:200px;height:112px;" alt="Learn" />
     </div>
     <div class="hp_title">
       Learn
@@ -130,9 +130,9 @@ redirect_from: /home.pml
 
 
   <div class="homepage_item">
-    <a class="divLink" href="/Foundation/Support/"></a>
+    <a class="divLink" href="Foundation/Support/"></a>
     <div class="hp_pic">
-      <img src="/images/support.png" style="width:150px;height:87px;" alt="Support" />
+      <img src="images/support.png" style="width:150px;height:87px;" alt="Support" />
     </div>
     <div class="hp_title">
       Support seL4
@@ -143,9 +143,9 @@ redirect_from: /home.pml
   </div>
 
   <div class="homepage_item">
-    <a class="divLink" href="/Foundation/Trademark/"></a>
+    <a class="divLink" href="Foundation/Trademark/"></a>
     <div class="hp_pic">
-      <img src="/images/scales.png" style="width:100px;height:76px;" alt="Branding" />
+      <img src="images/scales.png" style="width:100px;height:76px;" alt="Branding" />
     </div>
     <div class="hp_title">
       The seL4 Trademark
@@ -156,9 +156,9 @@ redirect_from: /home.pml
   </div>
 
   <div class="homepage_item">
-    <a class="divLink" href="/Foundation/Summit/2024/"></a>
+    <a class="divLink" href="Foundation/Summit/2024/"></a>
     <div class="hp_pic">
-      <img src="/images/sel4-summit-logo.svg" style="width:200px" alt="seL4 Summit" />
+      <img src="images/sel4-summit-logo.svg" style="width:200px" alt="seL4 Summit" />
     </div>
     <div class="hp_title">
       seL4 Summit
@@ -169,9 +169,9 @@ redirect_from: /home.pml
   </div>
 
   <div class="homepage_item">
-    <a class="divLink" href="/Contribute/"></a>
+    <a class="divLink" href="Contribute/"></a>
     <div class="hp_pic">
-      <img src="/images/contributing.jpg" style="width:200px;height:75px" alt="Contribute" />
+      <img src="images/contributing.jpg" style="width:200px;height:75px" alt="Contribute" />
     </div>
     <div class="hp_title">
       Contribute
@@ -182,9 +182,9 @@ redirect_from: /home.pml
   </div>
 
   <div class="homepage_item">
-    <a class="divLink" href="/Info/"></a>
+    <a class="divLink" href="Info/"></a>
     <div class="hp_pic">
-      <img src="/images/more_info.png" style="width:80px;height:95px;" alt="More info" />
+      <img src="images/more_info.png" style="width:80px;height:95px;" alt="More info" />
     </div>
     <div class="hp_title">
       Want to know more?

--- a/news/2020.html
+++ b/news/2020.html
@@ -34,7 +34,7 @@ layout: news
  <p>
 
    <a href="https://sel4.systems">
-     <img src="/images/seL4.svg"
+     <img src="../images/seL4.svg"
 	  style="width:30%; padding-left:1em; float:right"
 	  alt="seL4" />
    </a>
@@ -92,7 +92,7 @@ layout: news
  <p>
 
    <a href="https://www.adventiumlabs.com">
-     <img src="/Foundation/Membership/LOGOS/adventium-labs.svg"
+     <img src="../Foundation/Membership/LOGOS/adventium-labs.svg"
 	  style="width:40%; padding-left:1em; float:right"
 	  alt="Adventium Labs logo" />
    </a>
@@ -122,7 +122,7 @@ layout: news
  <p>
 
     <a href="https://riscv.org">
-      <img src="/Foundation/Membership/LOGOS/RISC-V.svg"
+      <img src="../Foundation/Membership/LOGOS/RISC-V.svg"
 	   style="width: 15%;  padding-left:10px;  float:right"
 	   alt="RISC-V logo" />
     </a>
@@ -160,7 +160,7 @@ layout: news
  <p>
 
     <a href="https://www.unsw.edu.au">
-      <img src="/Foundation/Membership/LOGOS/UNSW.svg"
+      <img src="../Foundation/Membership/LOGOS/UNSW.svg"
 	   style="width: 15%;  padding-left:10px;  float:right"
 	   alt="UNSW logo" />
     </a>
@@ -195,8 +195,8 @@ layout: news
 <div>
  <p>
 
-   <a href="/About/seL4-whitepaper.pdf">
-   <img src="/About/whitepaper.svg"
+   <a href="../About/seL4-whitepaper.pdf">
+   <img src="../About/whitepaper.svg"
    style="width:15%; padding-left:1em; padding-bottom:1em; float:right"
    alt="seL4 Whitepaper">
    </a>
@@ -226,7 +226,7 @@ layout: news
  <p>
 
    <a href="https://brkawy.com">
-   <img src="/Foundation/Membership/LOGOS/Brkawy.png"
+   <img src="../Foundation/Membership/LOGOS/Brkawy.png"
    style="width:40%; padding-left:1em; float:right"
    alt="Breakaway logo">
    </a>
@@ -262,24 +262,24 @@ layout: news
 <div>
   <p>
 
-   <img src="/images/mosaic.jpg"
+   <img src="../images/mosaic.jpg"
    style="width:30%; padding-left:1em; float:right"
    alt="seL4 foundation launch" />
 
    The <a href="https://trustworthy.systems">Trustworthy Systems
    group</a> is excited to announce the creation of the <a
-   href="/Foundation/">seL4 Foundation</a>. Its aim is to provide a
+   href="../Foundation/">seL4 Foundation</a>. Its aim is to provide a
    neutral and independent organisation to ensure the longevity of
    seL4, and grow its ecosystem of adopters and contributors.
 
-   It has a <a href="/Foundation/Board/">high-profile Board</a>
+   It has a <a href="../Foundation/Board/">high-profile Board</a>
    consisting of Gernot Heiser (Chair), June Andronick, Gerwin Klein,
    John Launchbury, Sascha Kegreiß, Daniel Potts.
 
    It already has a number of members, including major adopters
    HENSOLDT Cyber and Ghost Systems, and providers of services for
    seL4, Cog Systems and DornerWorks. Please check the <a
-   href="/Foundation/Membership/">membership page</a> for details and
+   href="../Foundation/Membership/">membership page</a> for details and
    how to join.
 
    The seL4 Foundation is set up under the Linux Foundation, which

--- a/news/2021.html
+++ b/news/2021.html
@@ -12,7 +12,7 @@ layout: news
  <p>
 
    <a href="https://www.rtx.com/">
-     <img src="/Foundation/Membership/LOGOS/raytheontechnologies.svg"
+     <img src="../Foundation/Membership/LOGOS/raytheontechnologies.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="Raytheon logo"/>
    </a>
@@ -35,7 +35,7 @@ layout: news
   <p>
 
     <a href="https://www.tii.ae">
-      <img src="/Foundation/Membership/LOGOS/TII.jpg"
+      <img src="../Foundation/Membership/LOGOS/TII.jpg"
 	   style="width: 20%;  padding-left:10px;  float:right"
 	   alt="TII logo" />
     </a>
@@ -68,7 +68,7 @@ layout: news
   <p>
 
     <a href="https://riscv.org">
-      <img src="/Foundation/Membership/LOGOS/RISC-V.svg"
+      <img src="../Foundation/Membership/LOGOS/RISC-V.svg"
 	   style="width: 20%;  padding-left:10px;  float:right"
 	   alt="RISC-V logo" />
     </a>
@@ -100,7 +100,7 @@ layout: news
 
 
  <a href="https://arc.gov.au">
-   <img src="/images/arc-logo.svg"
+   <img src="../images/arc-logo.svg"
 	style="width: 20%;  padding-left:10px;  float:right"
 	alt="ARC logo" />
  </a>
@@ -125,16 +125,16 @@ layout: news
   <p>
 
    <a href="https://proofcraft.systems">
-     <img src="/Foundation/Membership/LOGOS/proofcraft.svg"
+     <img src="../Foundation/Membership/LOGOS/proofcraft.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="Proofcraft logo">
    </a>
 
-   The seL4 Foundation has awarded <a href="/Foundation/Services/">Interim
+   The seL4 Foundation has awarded <a href="../Foundation/Services/">Interim
    Endorsement</a> to <a href="https://proofcraft.systems">Proofcraft</a> as a
    Trusted Service Provider for commercial support, verification projects,
    training and consulting on formal verification of seL4 and seL4-based
-   systems. More on our <a href="/Foundation/Services/">services and products
+   systems. More on our <a href="../Foundation/Services/">services and products
    page</a>.
 
  </p>
@@ -150,7 +150,7 @@ layout: news
  <p>
 
    <a href="https://www.rtx.com/">
-     <img src="/images/seL4.svg"
+     <img src="../images/seL4.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="seL4 logo"/>
    </a>
@@ -176,7 +176,7 @@ layout: news
  <p>
 
    <a href="https://proofcraft.systems">
-     <img src="/Foundation/Membership/LOGOS/proofcraft.svg"
+     <img src="../Foundation/Membership/LOGOS/proofcraft.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="Proofcraft logo">
    </a>
@@ -205,7 +205,7 @@ layout: news
  <p>
 
    <a href="https://xcalibyte.com">
-     <img src="/Foundation/Membership/LOGOS/xcalibyte.svg"
+     <img src="../Foundation/Membership/LOGOS/xcalibyte.svg"
 	  style="width: 15%;  padding-left:10px;  float:right"
 	  alt="Xcalibyte logo">
    </a>
@@ -232,7 +232,7 @@ layout: news
  <p>
 
    <a href="https://driveghost.com/">
-     <img src="/Foundation/Membership/LOGOS/GHOST.svg"
+     <img src="../Foundation/Membership/LOGOS/GHOST.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="Ghost logo" />
    </a>
@@ -267,7 +267,7 @@ layout: news
  <p>
 
    <a href="http://hensoldt-cyber.com/">
-   <img src="/Foundation/Membership/LOGOS/HENSOLDT_Cyber.svg"
+   <img src="../Foundation/Membership/LOGOS/HENSOLDT_Cyber.svg"
     style="width: 15%;  padding-left:10px;  float:right"
     alt="HENSOLDT Cyber">
    </a>
@@ -304,7 +304,7 @@ layout: news
  <p>
 
    <a href="https://www.lotuscars.com/">
-     <img src="/Foundation/Membership/LOGOS/LotusCarsTechnology.svg"
+     <img src="../Foundation/Membership/LOGOS/LotusCarsTechnology.svg"
           style="width: 15%;  padding-left:10px;  float:right"
           alt="Lotus Cars logo"/>
    </a>
@@ -346,7 +346,7 @@ layout: news
  <p>
 
    <a href="https://trustworthy.systems/projects/TS/SMACCM/">
-     <img src="/images/smaccmcopter-defcon.jpg"
+     <img src="../images/smaccmcopter-defcon.jpg"
 	  style="width: 50%;  padding-left:10px;  float:right"
 	  alt="SMACCMcopter at DEF CON" />
    </a>
@@ -381,7 +381,7 @@ layout: news
 <div>
   <p>
     <a href="https://www.k-state.edu/">
-      <img src="/Foundation/Membership/LOGOS/kansas-state.svg"
+      <img src="../Foundation/Membership/LOGOS/kansas-state.svg"
 	   style="width: 15%;  padding-left:10px;  float:right"
 	   alt="KSU logo" />
     </a>
@@ -403,7 +403,7 @@ layout: news
 </div>
 <div>
  <p>
-   <img src="/images/sel4-birthdaycake.png"
+   <img src="../images/sel4-birthdaycake.png"
    style="width: 15%;  padding-left:10px;  float:right"
    alt="seL4 birthday cake">
 
@@ -427,7 +427,7 @@ layout: news
    restrictions &mdash; so we’ll all be remote ;-)
  </p>
  <div class="highlight">
-  <img src="/images/seL4.svg" style="width:15%; padding-left:1em;" alt="seL4"><p>
+  <img src="../images/seL4.svg" style="width:15%; padding-left:1em;" alt="seL4"><p>
    Happy seL4 Day everyone!</p>
  </div>
  <p>
@@ -445,7 +445,7 @@ layout: news
 <div>
   <p>
     <a href="https://riscv.org">
-      <img src="/Foundation/Membership/LOGOS/RISC-V.svg"
+      <img src="../Foundation/Membership/LOGOS/RISC-V.svg"
 	   style="width: 20%;  padding-left:10px;  float:right"
 	   alt="RISC-V logo" />
     </a>
@@ -480,7 +480,7 @@ layout: news
  </p>
 
  <a href="https://arc.gov.au">
-   <img src="/images/arc-logo.svg"
+   <img src="../images/arc-logo.svg"
 	style="width: 20%;  padding-left:10px;  float:right"
 	alt="ARC logo" />
  </a>
@@ -514,7 +514,7 @@ layout: news
 <div>
   <p>
     <a href="https://www.tum.de/en">
-      <img src="/Foundation/Membership/LOGOS/TU-Munich.svg"
+      <img src="../Foundation/Membership/LOGOS/TU-Munich.svg"
 	   style="width: 15%;  padding-left:10px;  float:right"
 	   alt="TU Munich logo" />
     </a>
@@ -537,7 +537,7 @@ layout: news
  <p>
 
    <a href="https://secondstate.io">
-     <img src="/Foundation/Membership/LOGOS/secondstate.svg"
+     <img src="../Foundation/Membership/LOGOS/secondstate.svg"
 	  style="width: 15%;  padding-left:10px;  float:right"
 	  alt="Second State logo" />
    </a>
@@ -581,8 +581,8 @@ layout: news
   <table>
     <tr>
       <td>
-	<a href="/Foundation/Board/Horizon-Feng.jpg"><img
-						      src="/Foundation/Board/Horizon-Feng-s.jpg"
+	<a href="../Foundation/Board/Horizon-Feng.jpg"><img
+						      src="../Foundation/Board/Horizon-Feng-s.jpg"
 					alt="Dr Feng Zhou" width="80"
 						      /></a>
 	&nbsp; &nbsp;
@@ -598,8 +598,8 @@ layout: news
 
     <tr>
       <td>
-	<a href="/Foundation/Board/Li-Ian.png"><img
-					src="/Foundation/Board/Li-Ian-s.png"
+	<a href="../Foundation/Board/Li-Ian.png"><img
+					src="../Foundation/Board/Li-Ian-s.png"
 					alt="Ian Xu" width="80" /></a>
 	&nbsp; &nbsp;
       </td>
@@ -614,8 +614,8 @@ layout: news
 
     <tr>
       <td>
-	<a href="/Foundation/Board/Jump-Matt.jpg"><img
-					src="/Foundation/Board/Jump-Matt-s.jpg"
+	<a href="../Foundation/Board/Jump-Matt.jpg"><img
+					src="../Foundation/Board/Jump-Matt-s.jpg"
 					alt="Dr Matthew P. Grosvenor"
 					width="80" /></a>
 	&nbsp; &nbsp;
@@ -632,8 +632,8 @@ layout: news
 
     <tr>
       <td>
-	<a href="/Foundation/Board/NIO-Qiyan.png"><img
-						   src="/Foundation/Board/NIO-Qiyan-s.png"
+	<a href="../Foundation/Board/NIO-Qiyan.png"><img
+						   src="../Foundation/Board/NIO-Qiyan-s.png"
 						   alt="Qiyan Wang"
 						   width="80" /></a>
       </td>
@@ -650,7 +650,7 @@ layout: news
 
   <p>
     The four new members join five continuing members on
-    the <a href="/Foundation/Board/">seL4 Board</a>, taking the size of
+    the <a href="../Foundation/Board/">seL4 Board</a>, taking the size of
     the Board to nine.
   </p>
 </div>
@@ -665,7 +665,7 @@ layout: news
  <p>
 
    <a href="https://jumptrading.com/">
-     <img src="/Foundation/Membership/LOGOS/Jump-Trading.svg"
+     <img src="../Foundation/Membership/LOGOS/Jump-Trading.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="Jump Trading logo" />
    </a>
@@ -696,7 +696,7 @@ layout: news
  <p>
 
    <a href="https://horizon.ai">
-     <img src="/Foundation/Membership/LOGOS/Horizon_Robotics.svg"
+     <img src="../Foundation/Membership/LOGOS/Horizon_Robotics.svg"
 	  style="width: 25%;  padding-left:10px;  float:right"
 	  alt="Horizon Robotics logo" />
    </a>
@@ -745,7 +745,7 @@ layout: news
  <p>
 
    <a href="https://lixiang.com">
-     <img src="/Foundation/Membership/LOGOS/Li_Auto.svg"
+     <img src="../Foundation/Membership/LOGOS/Li_Auto.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="Li Auto logo" />
    </a>
@@ -791,7 +791,7 @@ layout: news
  <p>
 
    <a href="https://xcalibyte.com">
-     <img src="/Foundation/Membership/LOGOS/xcalibyte.svg"
+     <img src="../Foundation/Membership/LOGOS/xcalibyte.svg"
 	  style="width: 15%;  padding-left:10px;  float:right"
 	  alt="Xcalibyte logo">
    </a>
@@ -833,7 +833,7 @@ layout: news
  <p>
 
    <a href="https://nio.com">
-     <img src="/Foundation/Membership/LOGOS/NIO.svg"
+     <img src="../Foundation/Membership/LOGOS/NIO.svg"
 	  style="width: 15%;  padding-left:10px;  float:right"
 	  alt="NIO logo" />
    </a>
@@ -882,7 +882,7 @@ layout: news
 <div>
   <p>
     <a href="https://sel4.systems">
-      <img src="/images/seL4.svg" style="width:15%; padding-left:1em;
+      <img src="../images/seL4.svg" style="width:15%; padding-left:1em;
 	   float:right" alt="seL4" />
     </a>
 
@@ -934,7 +934,7 @@ layout: news
  <p>
 
    <a href="https://sel4.foundation">
-     <img src="/Foundation/Board/TS-June-s.jpg" alt="June Andronick" width="80"
+     <img src="../Foundation/Board/TS-June-s.jpg" alt="June Andronick" width="80"
 	  style="padding-left:10px;  float:right" />
    </a>
 
@@ -954,7 +954,7 @@ layout: news
 <div>
   <p>
     <a href="https://www.kry10.com/">
-      <img src="/Foundation/Membership/LOGOS/Kry10.svg"
+      <img src="../Foundation/Membership/LOGOS/Kry10.svg"
 	   style="width: 15%;  padding-left:10px;  float:right"
 	   alt="Kry10 logo" />
     </a>
@@ -989,7 +989,7 @@ layout: news
 
   <p>
     <a href="https://sel4.foundation">
-      <img src="/images/sel4-foundation-logo.svg" style="width: 15%;
+      <img src="../images/sel4-foundation-logo.svg" style="width: 15%;
 	   padding-left:10px; float:right" alt="seL4 Foundation logo" />
     </a>
 
@@ -1002,7 +1002,7 @@ layout: news
     The seL4 Foundation, as well as its members and ecosystem, want to
     reinforce their commitment to the success and support of seL4. The
     TS team will be rebuilding at UNSW and a number of
-    Foundation-endorsed <a href="/Foundation/Services">seL4 services
+    Foundation-endorsed <a href="../Foundation/Services">seL4 services
     providers</a> as well as the newly created <a
     href="https://proofcraft.systems">Proofcraft</a> verification
     company are dedicated to support seL4 in the future.
@@ -1032,7 +1032,7 @@ layout: news
 	  &ldquo;continuity project&rdquo;.</b><br>
 
       <a
-      href="/Foundation/Support">https://sel4.systems/Foundation/Support/</a><br>
+      href="../Foundation/Support">https://sel4.systems/Foundation/Support/</a><br>
       <a
       href="https://crowdfunding.lfx.linuxfoundation.org/projects/e94c998c-bac2-4224-b0ae-23f265fdd1a5">seL4 crowdfunding page</a><br>
 
@@ -1055,7 +1055,7 @@ layout: news
       <b> get more members signed up to the Foundation.</b><br>
 
       <a
-      href="/Foundation/Join">https://sel4.systems/Foundation/Join/</a><br>
+      href="../Foundation/Join">https://sel4.systems/Foundation/Join/</a><br>
 
       A push to get more organisations joining in the coming weeks
       will be a clear message of the strong support to seL4 and will
@@ -1094,7 +1094,7 @@ layout: news
 
       <b>jobs in the seL4 ecosystem.</b><br>
 
-      <a href="/Foundation/Jobs">
+      <a href="../Foundation/Jobs">
       https://sel4.systems/Foundation/Jobs/</a><br>
 
       While some expertise is needed to be kept within the Foundation,
@@ -1118,14 +1118,14 @@ layout: news
 <div>
   <p>
     <a href="https://sel4.foundation">
-      <img src="/images/sel4-foundation-logo.svg"
+      <img src="../images/sel4-foundation-logo.svg"
 	   style="width: 15%;  padding-left:10px;  float:right"
 	   alt="RISC-V logo" />
     </a>
 
    The community has expressed a need to more easily find seL4 experts
    to hire. The Foundations has created a <a
-   href="/Foundation/Jobs">"Jobs in seL4 ecosystem" page</a> where
+   href="../Foundation/Jobs">"Jobs in seL4 ecosystem" page</a> where
    members can post offers for positions with seL4 expertise.
  </p>
 </div>
@@ -1138,12 +1138,12 @@ layout: news
 <div>
   <p>
     <a href="https://riscv.org">
-      <img src="/Foundation/Membership/LOGOS/RISC-V.svg"
+      <img src="../Foundation/Membership/LOGOS/RISC-V.svg"
 	   style="width: 15%;  padding-left:10px;  float:right"
 	   alt="RISC-V logo" />
     </a>
 
-   Today, the <a href="/Foundation/">seL4 Foundation</a> and
+   Today, the <a href="../Foundation/">seL4 Foundation</a> and
    <a href="https://riscv.org">RISC-V International</a> announced that the
    verified seL4 microkernel on the RV64 architecture has been proved
    down to the executable code
@@ -1212,7 +1212,7 @@ layout: news
 <div>
   <p>
     <a href="https://ethz.ch/en.html">
-      <img src="/Foundation/Membership/LOGOS/ETH-Zurich.svg"
+      <img src="../Foundation/Membership/LOGOS/ETH-Zurich.svg"
 	   style="width: 15%;  padding-left:10px;  float:right"
 	   alt="ETH Zurich logo" />
     </a>
@@ -1246,7 +1246,7 @@ layout: news
 <div>
   <p>
     <a href="https://www.rtx.com/">
-      <img src="/Foundation/Membership/LOGOS/raytheontechnologies.svg"
+      <img src="../Foundation/Membership/LOGOS/raytheontechnologies.svg"
 	   style="width: 15%;  padding-left:10px;  float:right"
 	   alt="Raytheon logo" />
     </a>
@@ -1279,13 +1279,13 @@ layout: news
 <div>
  <p>
    <a href="http://hensoldt-cyber.com/">
-     <img src="/Foundation/Membership/LOGOS/HENSOLDT_Cyber.svg"
+     <img src="../Foundation/Membership/LOGOS/HENSOLDT_Cyber.svg"
 	  style="width: 15%;  padding-left:10px;  float:right"
 	  alt="HENSOLDT Cyber" />
    </a>
 
    The seL4 Foundation has extended <a
-   href="/Foundation/Services/">Interim Endorsement</a> as Trusted
+   href="../Foundation/Services/">Interim Endorsement</a> as Trusted
    Service Provider to <a href="http://hensoldt-cyber.com/">HENSOLDT
    Cyber</a>, for consulting and development services for seL4-based
    systems. More on:
@@ -1293,11 +1293,11 @@ layout: news
 
    <ul>
    <li>
-   <a href="/Foundation/Services/hc.html">HENSOLDT Cyber services
+   <a href="../Foundation/Services/hc.html">HENSOLDT Cyber services
    and products</a>;
    </li>
    <li>
-   <a href="/Foundation/Services/endorsement.html">the seL4
+   <a href="../Foundation/Services/endorsement.html">the seL4
    Foundation’s Interim Endorsement program</a>.
    </li>
    </ul>
@@ -1332,22 +1332,22 @@ layout: news
  Interim endorsement is intended to lead to full certification; the
  Foundation will work with interim endorsees and the general
  membership on developing certification schemes. <a
- href="/Foundation/Services/">More detail</a>.
+ href="../Foundation/Services/">More detail</a>.
  </p>
 
  <p>
    <a href="https://dornerworks.com/">
-   <img src="/Foundation/Membership/LOGOS/DornerWorks.svg"
+   <img src="../Foundation/Membership/LOGOS/DornerWorks.svg"
    style="width:15%; padding-left:1em"
    alt="DornerWorks logo">
    </a>
    <a href="https://brkawy.com/">
-   <img src="/Foundation/Membership/LOGOS/Brkawy.png"
+   <img src="../Foundation/Membership/LOGOS/Brkawy.png"
    style="width:15%; padding-left:1em"
    alt="Breakaway Consulting logo">
    </a>
    <a href="https://cog.systems/">
-   <img src="/Foundation/Membership/LOGOS/Cog.jpg"
+   <img src="../Foundation/Membership/LOGOS/Cog.jpg"
    style="width:15%; padding-left:1em"
    alt="Cog logo">
    </a>
@@ -1362,7 +1362,7 @@ layout: news
 <div>
   <p>
     <a href="https://www.penten.com/">
-     <img src="/Foundation/Membership/LOGOS/Penten.svg"
+     <img src="../Foundation/Membership/LOGOS/Penten.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="Penten logo" />
    </a>

--- a/news/2022.html
+++ b/news/2022.html
@@ -12,7 +12,7 @@ layout: news
  <p>
 
    <a href="https://www.rtx.com/">
-     <img src="/Foundation/Membership/LOGOS/raytheontechnologies.svg"
+     <img src="../Foundation/Membership/LOGOS/raytheontechnologies.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="Raytheon logo"/>
    </a>
@@ -34,7 +34,7 @@ layout: news
 </div>
 <div style="margin: auto; width: 50%;">
     <a href = "https://www.linuxfoundation.org/resources/publications/linux-foundation-annual-report-2022?hsLang=en">
-    <img src="/images/lf-annual-report.png"
+    <img src="../images/lf-annual-report.png"
     style="width: 70%;"
     alt="LF annual report" />
     </a>
@@ -49,8 +49,8 @@ layout: news
   11 November 2022: The videos and slides of the seL4 summit 2022 are available online
 </div>
 <div>
-  <a href="/Foundation/Summit/2022">
-    <img src="/images/sel4-summit-logo.svg"
+  <a href="../Foundation/Summit/2022">
+    <img src="../images/sel4-summit-logo.svg"
     style="width: 20%;  padding-left:10px;  float:right"
     alt="seL4 summit" />
   </a>
@@ -69,7 +69,7 @@ layout: news
 </div>
 <div>
   <a href="https://www.google.com/">
-    <img src="/Foundation/Membership/LOGOS/google-short.svg" style="width: 20%;  padding-left:10px;  float:right" alt="Google" />
+    <img src="../Foundation/Membership/LOGOS/google-short.svg" style="width: 20%;  padding-left:10px;  float:right" alt="Google" />
   </a>
   <p>
    The seL4 Foundation welcomes the <a href="https://opensource.googleblog.com/2022/10/announcing-kataos-and-sparrow.html">open-sourcing of core components of KataOS</a> created by our Member <a href="https://google.com">Google</a>. KataOS is based on seL4 and implemented mostly in the <a href="https://www.rust-lang.org">Rust programming language</a>. KataOS is to be combined with a secure hardware platform on the RISC-V architecture.
@@ -89,13 +89,13 @@ layout: news
 <div>
   <p>
    <a href="https://xcalibyte.com">
-     <img src="/Foundation/Membership/LOGOS/xcalibyte.svg"
+     <img src="../Foundation/Membership/LOGOS/xcalibyte.svg"
 	  style="width: 15%;  padding-left:10px;  float:right"
 	  alt="Xcalibyte logo">
    </a>
   </p>
   <p>
-    The seL4 Foundation thanks <a href="https://xcalibyte.com">Xcalibyte</a> for becoming a Bronze sponsor of the <a href="/Foundation/Summit/2022">seL4 Summit 2022</a>.
+    The seL4 Foundation thanks <a href="https://xcalibyte.com">Xcalibyte</a> for becoming a Bronze sponsor of the <a href="../Foundation/Summit/2022">seL4 Summit 2022</a>.
   </p>
   <p>
     Xcalibyte's mission is to improve the quality of software by
@@ -122,7 +122,7 @@ layout: news
 </div>
 <div>
   <p>
-    We are very fortunate to welcome four leaders at major funding agencies to participate in a session <a href="../Foundation/Summit/2022/abstracts2022#a-Funding-agencies"><strong>Funding agencies: priorities and vision</strong></a> at the <a href="/Foundation/Summit/2022/">seL4 summit</a>. They will each give their views on the priorities and vision of their agency in terms of high-assurance systems.
+    We are very fortunate to welcome four leaders at major funding agencies to participate in a session <a href="../Foundation/Summit/2022/abstracts2022#a-Funding-agencies"><strong>Funding agencies: priorities and vision</strong></a> at the <a href="../Foundation/Summit/2022/">seL4 summit</a>. They will each give their views on the priorities and vision of their agency in terms of high-assurance systems.
   </p>
 </div>
 <div class="speakers_grid">
@@ -131,7 +131,7 @@ layout: news
       <img src="../../images/summit/brad.jpg" alt="William “Brad” Martin" width="140"/>
     </div>
     <div class="speaker_title" style="text-align:center">
-      <a href="/Foundation/Summit/2022/abstracts2022#a-Funding-agencies-darpa">William “Brad” Martin</a>
+      <a href="../Foundation/Summit/2022/abstracts2022#a-Funding-agencies-darpa">William “Brad” Martin</a>
       <br>
       <a href="https://www.darpa.mil/">DARPA</a>
     </div>
@@ -141,7 +141,7 @@ layout: news
       <img src="../../images/summit/paul.jpg" alt="Paul Waller" width="140"/>
     </div>
     <div class="speaker_title" style="text-align:center">
-      <a href="/Foundation/Summit/2022/abstracts2022#a-Funding-agencies-ncsc">Paul Waller</a>
+      <a href="../Foundation/Summit/2022/abstracts2022#a-Funding-agencies-ncsc">Paul Waller</a>
       <br>
       <a href="https://www.ncsc.gov.uk/">NCSC</a>
     </div>
@@ -151,7 +151,7 @@ layout: news
       <img src="../../images/summit/cyberagentur.png" alt="Cyberagentur" width="140"/>
     </div>
     <div class="speaker_title" style="text-align:center">
-      <a href="/Foundation/Summit/2022/abstracts2022#a-Funding-agencies-cyberagentur">Sebastian Jester</a>
+      <a href="../Foundation/Summit/2022/abstracts2022#a-Funding-agencies-cyberagentur">Sebastian Jester</a>
       <br>
       <a href="https://www.cyberagentur.de/">Cyberagentur</a>
     </div>
@@ -161,7 +161,7 @@ layout: news
       <img src="../../images/summit/ticky.jpg" alt="Dr. Shreekant (Ticky) Thakkar" width="140"/>
     </div>
     <div class="speaker_title" style="text-align:center">
-      <a href="/Foundation/Summit/2022/abstracts2022#a-Funding-agencies-tii">Shreekant (Ticky) Thakkar</a>
+      <a href="../Foundation/Summit/2022/abstracts2022#a-Funding-agencies-tii">Shreekant (Ticky) Thakkar</a>
       <br>
       <a href="https://www.tii.ae/">TII</a>
     </div>
@@ -178,12 +178,12 @@ layout: news
 <div>
   <p>
     <a href="https://dornerworks.com/">
-    <img src="/Foundation/Membership/LOGOS/DornerWorks.svg" style="width: 20%;  padding-left:10px;  float:right"
+    <img src="../Foundation/Membership/LOGOS/DornerWorks.svg" style="width: 20%;  padding-left:10px;  float:right"
               alt="DornerWorks logo">
         </a>
   </p>
   <p>
-    The seL4 Foundation thanks <a href="https://dornerworks.com/">DornerWorks</a> for becoming a Bronze sponsor of the <a href="/Foundation/Summit/2022/">seL4 Summit 2022</a>.
+    The seL4 Foundation thanks <a href="https://dornerworks.com/">DornerWorks</a> for becoming a Bronze sponsor of the <a href="../Foundation/Summit/2022/">seL4 Summit 2022</a>.
   </p>
   <p>
     <a href="https://dornerworks.com/">DornerWorks</a> helps product makers turn their ideas into reality with FPGA, hardware, and embedded software engineering expertise. Among other areas, DornerWorks specialises in seL4 microkernel-based development.
@@ -206,12 +206,12 @@ layout: news
 <div>
   <p>
     <a href="https://horizon.ai/">
-    <img src="/Foundation/Membership/LOGOS/Horizon_Robotics.svg" style="width: 20%;  padding-left:10px;  float:right"
+    <img src="../Foundation/Membership/LOGOS/Horizon_Robotics.svg" style="width: 20%;  padding-left:10px;  float:right"
               alt="Horizon Robotics logo">
         </a>
   </p>
   <p>
-    The seL4 Foundation thanks <a href="https://horizon.ai/">Horizon Robotics</a> for becoming a Bronze sponsor of the <a href="/Foundation/Summit/2022/">seL4 Summit 2022</a>.
+    The seL4 Foundation thanks <a href="https://horizon.ai/">Horizon Robotics</a> for becoming a Bronze sponsor of the <a href="../Foundation/Summit/2022/">seL4 Summit 2022</a>.
   </p>
   <p>
     Horizon Robotics is a leading provider of computing platforms for smart vehicles with the mission to make human life safer and better.
@@ -234,7 +234,7 @@ layout: news
 <div>
   <p>
   <a href="https://spacemit.com/en/">
-      <img src="/Foundation/Membership/LOGOS/SpacemiT.svg" style="width: 20%;  padding-left:10px;  float:right" alt="SpacemiT" />
+      <img src="../Foundation/Membership/LOGOS/SpacemiT.svg" style="width: 20%;  padding-left:10px;  float:right" alt="SpacemiT" />
   </a>
   </p>
   <p>
@@ -255,8 +255,8 @@ layout: news
 <div>
 
   <p>
-    <a href="/Foundation/Summit/2022/">
-      <img src="/images/sel4-summit-logo.svg"
+    <a href="../Foundation/Summit/2022/">
+      <img src="../images/sel4-summit-logo.svg"
 	   style="width: 20%;  padding-left:10px;  float:right"
 	   alt="seL4 summit" />
     </a>
@@ -302,7 +302,7 @@ layout: news
 
   <p>
     <a href="https://www.google.com/">
-      <img src="/Foundation/Membership/LOGOS/google-short.svg" style="width: 20%;  padding-left:10px;  float:right" alt="Google" />
+      <img src="../Foundation/Membership/LOGOS/google-short.svg" style="width: 20%;  padding-left:10px;  float:right" alt="Google" />
      </a>
 
    The seL4 Foundation is pleased to welcome <a href="https://www.google.com/">Google</a> as our latest member.
@@ -323,8 +323,8 @@ layout: news
 <div>
 
   <p>
-    <a href="/Foundation/Summit/2022/">
-      <img src="/images/sel4-summit-logo.svg"
+    <a href="../Foundation/Summit/2022/">
+      <img src="../images/sel4-summit-logo.svg"
 	   style="width: 20%;  padding-left:10px;  float:right"
 	   alt="seL4 summit" />
     </a>
@@ -358,7 +358,7 @@ layout: news
 <div>
   <p>
     <a href="https://latticex.foundation/">
-      <img src="/Foundation/Membership/LOGOS/latticex.png"
+      <img src="../Foundation/Membership/LOGOS/latticex.png"
 	   style="width: 20%;  padding-left:10px;  float:right"
 	   alt="LatticeX" />
     </a>
@@ -452,7 +452,7 @@ A reminder that you have until Monday 9th of May 2022 to <a href="../Foundation/
 </div>
 <div>
     <a href="../">
-      <img src="/images/seL4.svg"
+      <img src="../images/seL4.svg"
 	   style="width: 20%;  padding-left:10px;  float:right"
 	   alt="seL4"/>
     </a>
@@ -577,7 +577,7 @@ A reminder that you have until Monday 9th of May 2022 to <a href="../Foundation/
 <div>
 
     <a href="https://de.linkedin.com/in/olivier-engelkes-6393b1a">
-      <img src="/Foundation/Board/HC-Olivier.jpg"
+      <img src="../Foundation/Board/HC-Olivier.jpg"
 	   style="width: 20%;  padding-left:10px;  float:right"
 	   alt="Olivier Engelkes" />
     </a>
@@ -604,7 +604,7 @@ A reminder that you have until Monday 9th of May 2022 to <a href="../Foundation/
 
   <p>
     <a href="https://www.ncsc.gov.uk/">
-      <img src="/Foundation/Membership/LOGOS/NCSC.png"
+      <img src="../Foundation/Membership/LOGOS/NCSC.png"
 	   style="width: 20%;  padding-left:10px;  float:right"
 	   alt="NCSC" />
     </a>
@@ -636,8 +636,8 @@ A reminder that you have until Monday 9th of May 2022 to <a href="../Foundation/
 <div>
 
   <p>
-    <a href="/Foundation/Summit/2022/">
-      <img src="/images/seL4.svg"
+    <a href="../Foundation/Summit/2022/">
+      <img src="../images/seL4.svg"
 	   style="width: 20%;  padding-left:10px;  float:right"
 	   alt="seL4 summit" />
     </a>
@@ -662,7 +662,7 @@ A reminder that you have until Monday 9th of May 2022 to <a href="../Foundation/
   </strong>
   </p>
   <p>
-  More information <a href="/Foundation/Summit/2022/">here</a>.
+  More information <a href="../Foundation/Summit/2022/">here</a>.
   </p>
 
 </div>
@@ -678,7 +678,7 @@ A reminder that you have until Monday 9th of May 2022 to <a href="../Foundation/
 <div>
   <p>
     <a href="https://www.kry10.com/">
-      <img src="/Foundation/Membership/LOGOS/Kry10.svg"
+      <img src="../Foundation/Membership/LOGOS/Kry10.svg"
 	   style="width: 20%;  padding-left:10px;  float:right"
 	   alt="Kry10 logo" />
     </a>

--- a/news/2023.html
+++ b/news/2023.html
@@ -12,7 +12,7 @@ layout: news
  <p>
 
    <a href="https://www.rtx.com/">
-     <img src="/Foundation/Membership/LOGOS/raytheontechnologies.svg"
+     <img src="../Foundation/Membership/LOGOS/raytheontechnologies.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="Raytheon logo"/>
    </a>
@@ -34,7 +34,7 @@ layout: news
 </div>
 <div class="news-text-container">
   <a href = "/images/hacms-award.jpg">
-    <img src="/images/hacms-award.jpg"
+    <img src="../images/hacms-award.jpg"
     style="width:350px; padding-left:1.5em; float:right"
     alt="DARPA Game Changer Award" />
   </a>
@@ -83,12 +83,12 @@ layout: news
 </div>
 <div class="news-text-container">
     <a href="https://nio.com/">
-       <img src="/Foundation/Membership/LOGOS/NIO.svg"
+       <img src="../Foundation/Membership/LOGOS/NIO.svg"
        style="width:200px; padding-left:1.5em; float:right"
       alt="nio">
     </a>
   <p>
-    We are excited to share that <a href="https://nio.com/">NIO</a> recently unveiled their <a href="https://www.linkedin.com/posts/qiyan-wang-8b0b2145_skyos-was-unveiled-to-the-public-for-the-activity-7110702765789642752-Iys0">seL4-based SkyOS operating system</a>, designed for Software Defined Vehicles, which they have been working on relentlessly for the past two years. At the <a href="/Foundation/Summit/2023">seL4 Summit 2023</a> Qiyan Wang, NIO’s Global VP of Digital Systems, <a href="https://www.youtube.com/watch?v=HfvX2VbWp6c&list=PLtoQeavghzr2qwDaad0hhsBBJMjkX_o4O&index=28" target="_blank">announced that NIO cars based on seL4 are planned for next year!</a>
+    We are excited to share that <a href="https://nio.com/">NIO</a> recently unveiled their <a href="https://www.linkedin.com/posts/qiyan-wang-8b0b2145_skyos-was-unveiled-to-the-public-for-the-activity-7110702765789642752-Iys0">seL4-based SkyOS operating system</a>, designed for Software Defined Vehicles, which they have been working on relentlessly for the past two years. At the <a href="../Foundation/Summit/2023">seL4 Summit 2023</a> Qiyan Wang, NIO’s Global VP of Digital Systems, <a href="https://www.youtube.com/watch?v=HfvX2VbWp6c&list=PLtoQeavghzr2qwDaad0hhsBBJMjkX_o4O&index=28" target="_blank">announced that NIO cars based on seL4 are planned for next year!</a>
   </p>
 </div>
 
@@ -102,18 +102,18 @@ layout: news
 <div class="news-text-container">
   <div id="floated-imgs">
     <a href="https://brkawy.com/">
-      <img src="/Foundation/Membership/LOGOS/Brkawy.png" style="width: 200px; padding:20px; float: right" alt="Breakaway Consulting logo">
+      <img src="../Foundation/Membership/LOGOS/Brkawy.png" style="width: 200px; padding:20px; float: right" alt="Breakaway Consulting logo">
     </a>
     <div class="style:clear:both"></div>
       <a href="https://unsw.edu.au/">
-      <img src="/Foundation/Membership/LOGOS/UNSW.svg" style="width: 200px; padding:20px; float: right" alt="UNSW logo">
+      <img src="../Foundation/Membership/LOGOS/UNSW.svg" style="width: 200px; padding:20px; float: right" alt="UNSW logo">
       </a>
   </div>
   <p>
      The <a href="https://docs.sel4.systems/projects/microkit/">seL4 Microkit</a>, formerly known as the Core Platform, is an operating system framework on top of seL4 provides a small set of simple abstractions that ease the design and implementation of statically structured systems on seL4, while still leveraging the kernel’s benefits of security and performance. The Microkit is distributed as an SDK that integrates with the developer’s build system of choice, significantly reducing the barrier to entry for new users of seL4.
   </p>
   <p>
-    The seL4 Microkit was developed in collaboration between <a href="https://brkawy.com/">Breakaway Consulting Pty Ltd</a> and <a href="https://trustworthy.systems/">Trustworthy Systems, UNSW</a>, and is now an official <a href="/Foundation"> seL4 Foundation</a> project, making it part of the seL4 eco-system.
+    The seL4 Microkit was developed in collaboration between <a href="https://brkawy.com/">Breakaway Consulting Pty Ltd</a> and <a href="https://trustworthy.systems/">Trustworthy Systems, UNSW</a>, and is now an official <a href="../Foundation"> seL4 Foundation</a> project, making it part of the seL4 eco-system.
   </p>
 </div>
 
@@ -124,7 +124,7 @@ layout: news
 </div>
 <div>
   <a href="https://www.rust-lang.org/">
-    <img src="/images/rust-logo-blk.svg"
+    <img src="../images/rust-logo-blk.svg"
     style="width: 20%;  padding-left:10px;  float:right"
     alt="Rust logo" />
   </a>
@@ -133,7 +133,7 @@ layout: news
   For the last year, Nick Spinale, funded by the seL4 Foundation, has been developing support for the Rust programming language in seL4 userspace.
   </p>
   <p>
-    Nick has created a comprehensive language support infrastructure that integrates well with the rest of the seL4 ecosystem (capDL, Microkit, sel4test) and also integrates well with what Rust programmers would expect from the language side. This work has now been accepted by the seL4 Foundation <a href="/Foundation/TSC">Technical Steering Committee</a> and can be found on <a href="https://github.com/seL4/rust-sel4">GitHub</a>. Nick’s talk at the recent seL4 summit is on <a href="https://youtu.be/J17lC124_9s?si=e8nDp-x8OLq6h1dO">seL4’s Youtube channel</a>. A demo system that uses the device driver framework, asynchronous programming in Rust and library support from the Rust ecosystem to implement a small web server is available on <a href="https://github.com/seL4/rust-microkit-http-server-demo">GitHub</a>.
+    Nick has created a comprehensive language support infrastructure that integrates well with the rest of the seL4 ecosystem (capDL, Microkit, sel4test) and also integrates well with what Rust programmers would expect from the language side. This work has now been accepted by the seL4 Foundation <a href="../Foundation/TSC">Technical Steering Committee</a> and can be found on <a href="https://github.com/seL4/rust-sel4">GitHub</a>. Nick’s talk at the recent seL4 summit is on <a href="https://youtu.be/J17lC124_9s?si=e8nDp-x8OLq6h1dO">seL4’s Youtube channel</a>. A demo system that uses the device driver framework, asynchronous programming in Rust and library support from the Rust ecosystem to implement a small web server is available on <a href="https://github.com/seL4/rust-microkit-http-server-demo">GitHub</a>.
   </p>
   <p>
     The overall outcome will be to allow people to write safer user-level code on top of seL4 without needing full formal verification, with a language that is receiving increasing interest and that aligns extremely well with security and safety critical embedded systems programming.
@@ -173,12 +173,12 @@ layout: news
 
 <p style="text-align: center; padding:20px">
   <a href="https://xcalibyte.com">
-    <img src="/Foundation/Membership/LOGOS/xcalibyte.svg"
+    <img src="../Foundation/Membership/LOGOS/xcalibyte.svg"
       style="width: 18%; padding-left:1em;"
       alt="XCalibyte logo" />
   </a>
   <a href="https://proofcraft.systems">
-    <img src="/Foundation/Membership/LOGOS/proofcraft.svg"
+    <img src="../Foundation/Membership/LOGOS/proofcraft.svg"
       style="width: 20%; padding-left:1em;"
       alt="Proofcraft logo" />
   </a>
@@ -192,13 +192,13 @@ layout: news
   18 October 2023: The videos and slides of the seL4 summit 2023 are available online
 </div>
 <div>
-  <a href="/Foundation/Summit/2023">
-    <img src="/images/sel4-summit-logo.svg"
+  <a href="../Foundation/Summit/2023">
+    <img src="../images/sel4-summit-logo.svg"
     style="width: 20%;  padding-left:10px;  float:right"
     alt="seL4 summit" />
   </a>
   <p>
-    Videos of the <a href="/Foundation/Summit/2023">seL4 summit 2023</a> are now available on the <a href="https://www.youtube.com/@seL4" target="_blank">seL4 YouTube channel</a>! Links and slides can be found on the summit <a href="../Foundation/Summit/2023/program">Program</a> and <a href="../Foundation/Summit/2023/abstracts2023">Abstracts</a> pages. Thanks to all the speakers for making the seL4 summit 2023 a great success!
+    Videos of the <a href="../Foundation/Summit/2023">seL4 summit 2023</a> are now available on the <a href="https://www.youtube.com/@seL4" target="_blank">seL4 YouTube channel</a>! Links and slides can be found on the summit <a href="../Foundation/Summit/2023/program">Program</a> and <a href="../Foundation/Summit/2023/abstracts2023">Abstracts</a> pages. Thanks to all the speakers for making the seL4 summit 2023 a great success!
   </p>
 </div>
 
@@ -209,13 +209,13 @@ layout: news
 <div>
   <p>
    <a href="https://ku.edu/">
-     <img src="/Foundation/Membership/LOGOS/ku-institute.svg"
+     <img src="../Foundation/Membership/LOGOS/ku-institute.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="KU Institute for Information Sciences logo">
    </a>
   </p>
   <p>
-    The seL4 Foundation is pleased to welcome <a href="https://ku.edu/">The University of Kansas</a> as Associate <a href="/Foundation/Membership/">Member</a>. KU has collaborated with a number of seL4 Foundation members along the years, including in the DARPA CASE project, which produced a set of formal methods tools that can be applied throughout the design and build process to create seL4-based high-assurance cyber-resilient systems.
+    The seL4 Foundation is pleased to welcome <a href="https://ku.edu/">The University of Kansas</a> as Associate <a href="../Foundation/Membership/">Member</a>. KU has collaborated with a number of seL4 Foundation members along the years, including in the DARPA CASE project, which produced a set of formal methods tools that can be applied throughout the design and build process to create seL4-based high-assurance cyber-resilient systems.
   </p>
 </div>
 
@@ -226,13 +226,13 @@ layout: news
 <div>
   <p>
    <a href="https://www.nio.com">
-     <img src="/Foundation/Membership/LOGOS/NIO.svg"
+     <img src="../Foundation/Membership/LOGOS/NIO.svg"
 	  style="width: 15%;  padding-left:10px;  float:right"
 	  alt="NIO logo">
    </a>
   </p>
   <p>
-    The seL4 Foundation thanks <a href="https://www.nio.com">NIO</a> for sponsoring both the reception and dinner for the <a href="/Foundation/Summit/2023">seL4 Summit
+    The seL4 Foundation thanks <a href="https://www.nio.com">NIO</a> for sponsoring both the reception and dinner for the <a href="../Foundation/Summit/2023">seL4 Summit
     2023</a>. NIO is also a <a href="#sponsor23-nio">gold sponsor</a> of the summit.
   </p>
   <p>
@@ -248,13 +248,13 @@ layout: news
 </div>
 <div>
   <p>
-    We are very fortunate to welcome five industry leaders to participate at the <a href="/Foundation/Summit/2023">seL4 Summit 2023</a>, in a session <a href="https://events.linuxfoundation.org/sel4-summit/program/schedule/">OS on seL4: so many options!</a>. Gapfruit, Kry10, Magnetite (MIT), and UNSW will present their views on the priorities and vision for their OS on seL4. The panel will be moderated by Todd Carpenter from Galois.
+    We are very fortunate to welcome five industry leaders to participate at the <a href="../Foundation/Summit/2023">seL4 Summit 2023</a>, in a session <a href="https://events.linuxfoundation.org/sel4-summit/program/schedule/">OS on seL4: so many options!</a>. Gapfruit, Kry10, Magnetite (MIT), and UNSW will present their views on the priorities and vision for their OS on seL4. The panel will be moderated by Todd Carpenter from Galois.
   </p>
 
   <div class="speakers_grid">
     <div class="speaker">
       <div class="speaker_pic">
-        <img src="../../images/summit/sid.jpg" alt="Sid Hussmann" height="100"/>
+        <img src="../images/summit/sid.jpg" alt="Sid Hussmann" height="100"/>
       </div>
       <div class="speaker_title" style="text-align:center">
         Sid Hussmann
@@ -264,7 +264,7 @@ layout: news
     </div>
     <div class="speaker">
       <div class="speaker_pic">
-        <img src="../../images/tsc/kent.jpg" alt="Kent McLeod" height="100"/>
+        <img src="../images/tsc/kent.jpg" alt="Kent McLeod" height="100"/>
       </div>
       <div class="speaker_title" style="text-align:center">
         Kent McLeod
@@ -274,7 +274,7 @@ layout: news
     </div>
     <div class="speaker">
       <div class="speaker_pic">
-        <img src="../../images/summit/juliana.jpeg" alt="Juliana Furgala" height="100"/>
+        <img src="../images/summit/juliana.jpeg" alt="Juliana Furgala" height="100"/>
       </div>
       <div class="speaker_title" style="text-align:center">
         Juliana Furgala
@@ -294,7 +294,7 @@ layout: news
     </div>
     <div class="speaker">
       <div class="speaker_pic">
-        <img src="../../images/summit/todd.jpg" alt="Todd Carpenter" height="100"/>
+        <img src="../images/summit/todd.jpg" alt="Todd Carpenter" height="100"/>
       </div>
       <div class="speaker_title" style="text-align:center">
         Todd Carpenter, Moderator <br>
@@ -311,14 +311,14 @@ layout: news
 <div>
   <p>
    <a href="https://www.tii.ae">
-     <img src="/Foundation/Membership/LOGOS/TII.jpg"
+     <img src="../Foundation/Membership/LOGOS/TII.jpg"
 	  style="width: 25%;  padding-left:10px; float:right"
 	  alt="TII logo">
    </a>
   </p>
   <p>
     The seL4 Foundation thanks <a href="https://www.tii.ae/">TII</a> for
-    becoming a Gold sponsor of the <a href="/Foundation/Summit/2023">seL4 Summit
+    becoming a Gold sponsor of the <a href="../Foundation/Summit/2023">seL4 Summit
     2023</a>.
   </p>
   <p>
@@ -340,21 +340,21 @@ layout: news
 
   <p>
    <a href="https://www.kry10.com/">
-     <img src="/Foundation/Membership/LOGOS/Kry10.svg"
+     <img src="../Foundation/Membership/LOGOS/Kry10.svg"
 	  style="width: 25%;  padding-left:10px;  float:right"
 	  alt="Kry10 logo">
    </a>
   </p>
   <p>
     The seL4 Foundation thanks <a href="https://www.kry10.com/">Kry10</a> for
-    becoming a Gold sponsor of the <a href="/Foundation/Summit/2023">seL4 Summit
+    becoming a Gold sponsor of the <a href="../Foundation/Summit/2023">seL4 Summit
     2023</a>.
   </p>
   <p>
     Kry10 offers a full-featured operating system on top of the seL4 kernel, along with tooling, services, key management and more. The Kry10 Platform is a fast and easy way to build highly secure, next-generation cyber-physical devices. It leverages the verification of seL4 to provide a secure, self-healing, truly dynamic system with minimal downtime, even during upgrades.
   </p>
   <p>
-    Kry10 is an <a href="/Foundation/Services/">Endorsed Service Provider</a> of the seL4 Foundation, offering support to enable seL4-based secure projects to be affordable, maintainable, and remotely manageable.
+    Kry10 is an <a href="../Foundation/Services/">Endorsed Service Provider</a> of the seL4 Foundation, offering support to enable seL4-based secure projects to be affordable, maintainable, and remotely manageable.
   </p>
   <p>
     See <a href="https://events.linuxfoundation.org/sel4-summit/sponsor/">here</a> if
@@ -370,14 +370,14 @@ layout: news
 
   <p>
    <a href="https://www.collinsaerospace.com">
-     <img src="/Foundation/Membership/LOGOS/Collins_Aerospace_Logo.svg"
+     <img src="../Foundation/Membership/LOGOS/Collins_Aerospace_Logo.svg"
 	  style="width: 25%;  padding-left:10px;  float:right"
 	  alt="Collins Aerospace logo">
    </a>
   </p>
   <p>
     The seL4 Foundation thanks <a href="https://www.collinsaerospace.com">Collins Aerospace</a> for
-    becoming a Silver sponsor of the <a href="/Foundation/Summit/2023">seL4 Summit
+    becoming a Silver sponsor of the <a href="../Foundation/Summit/2023">seL4 Summit
     2023</a>.
   </p>
   <p>
@@ -393,7 +393,7 @@ layout: news
    initialisation and configuration of systems architectures.
   </p>
   <p>
-   The <a href="/Foundation/Summit/2023">seL4 Summit 2023</a> will take place in
+   The <a href="../Foundation/Summit/2023">seL4 Summit 2023</a> will take place in
    Minneapolis, home town of this Collins Aerospace team involved in seL4.
   </p>
   <p>
@@ -412,14 +412,14 @@ layout: news
 
   <p>
    <a href="https://www.nio.com">
-     <img src="/Foundation/Membership/LOGOS/NIO.svg"
+     <img src="../Foundation/Membership/LOGOS/NIO.svg"
 	  style="width: 15%;  padding-left:10px;  float:right"
 	  alt="NIO logo">
    </a>
   </p>
   <p>
     The seL4 Foundation thanks <a href="https://www.nio.com">NIO</a> for
-    becoming our first Gold sponsor of the <a href="/Foundation/Summit/2023">seL4 Summit
+    becoming our first Gold sponsor of the <a href="../Foundation/Summit/2023">seL4 Summit
     2023</a>.
   </p>
   <p>
@@ -444,7 +444,7 @@ layout: news
 </div>
 <div>
   <a href = "../Foundation/Summit/2023">
-    <img src="/images/sel4-summit-logo.svg"
+    <img src="../images/sel4-summit-logo.svg"
     style="width: 15%; float:right"
     alt="seL4 summit" />
   </a>
@@ -457,7 +457,7 @@ layout: news
   </p>
   <p style="text-align: center; padding:20px">
   <a href = "https://sel4summit2023.sched.com/">
-    <img src="/images/summit/program-at-a-glance-2023.svg"
+    <img src="../images/summit/program-at-a-glance-2023.svg"
     alt="seL4 summit 2023 program" />
   </a>
   </p>
@@ -474,7 +474,7 @@ layout: news
     We are pleased to announce that the two keynotes for the <a href="../Foundation/Summit/2023">seL4 summit 2023</a> will be <strong>Gage from NCSC</strong> and <strong>Sam Leffler from Google</strong>! Gage will talk about <a href="../Foundation/Summit/2023/abstracts2023.html#a-scoping-assurance">Scoping assurance activities with seL4</a> and Sam about <a href="../Foundation/Summit/2023/abstracts2023.html#a-cantripos">CantripOS: An OS for Ambient ML Applications</a>.
   </p>
   <a href="https://www.ncsc.gov.uk/">
-    <img src="/Foundation/Membership/LOGOS/NCSC.png"
+    <img src="../Foundation/Membership/LOGOS/NCSC.png"
       style="width: 20%; float:right;"
       alt="NCSC logo" />
   </a>
@@ -484,7 +484,7 @@ layout: news
   </div>
   <div class="row" style="margin-left:0px; margin-right:0px">
   <a href="https://www.google.com/">
-    <img src="/Foundation/Membership/LOGOS/google.svg"
+    <img src="../Foundation/Membership/LOGOS/google.svg"
     style="width: 20%; float:right;"
     alt="Google logo" />
   </a>
@@ -501,12 +501,12 @@ layout: news
 </div>
 <div>
   <a href = "https://galois.com/">
-    <img src="/Foundation/Membership/LOGOS/galois-logo.svg"
+    <img src="../Foundation/Membership/LOGOS/galois-logo.svg"
     style="width: 15%; float:right"
     alt="Galois logo" />
   </a>
   <p>
-    We are pleased to have <a href="https://galois.com/">Galois</a> now part of the seL4 Foundation, following its acquisition of Adventium labs, which has been a <a href="/Foundation/Membership/">member</a> since 2020 and user of seL4 technologies for years before that. Galois develops technology to guarantee the trustworthiness of systems where failure is unacceptable. They apply cutting edge computer science and mathematics to advance the state of the art in software and hardware trustworthiness.  The seL4 Foundation looks forward to our continuing collaboration.
+    We are pleased to have <a href="https://galois.com/">Galois</a> now part of the seL4 Foundation, following its acquisition of Adventium labs, which has been a <a href="../Foundation/Membership/">member</a> since 2020 and user of seL4 technologies for years before that. Galois develops technology to guarantee the trustworthiness of systems where failure is unacceptable. They apply cutting edge computer science and mathematics to advance the state of the art in software and hardware trustworthiness.  The seL4 Foundation looks forward to our continuing collaboration.
   </p>
 </div>
 
@@ -518,7 +518,7 @@ layout: news
 </div>
 <div>
   <a href = "../Foundation/Summit/2023">
-    <img src="/images/sel4-summit-logo.svg"
+    <img src="../images/sel4-summit-logo.svg"
     style="width: 15%; float:right"
     alt="seL4 summit" />
   </a>
@@ -552,7 +552,7 @@ layout: news
 </div>
 <div>
   <a href = "https://awards.acm.org/software-system">
-    <img src="/images/acm-2023.svg"
+    <img src="../images/acm-2023.svg"
     style="width: 40%; float:right;"
     alt="ACM Award Winners" />
   </a>
@@ -575,7 +575,7 @@ layout: news
 </div>
 <div>
   <a href = "../Foundation/Summit/2023">
-    <img src="/images/sel4-summit-logo.svg"
+    <img src="../images/sel4-summit-logo.svg"
     style="width: 15%; float:right"
     alt="seL4 summit" />
   </a>
@@ -601,12 +601,12 @@ layout: news
 </div>
 <div>
   <a href = "https://autoware.org/">
-    <img src="/Foundation/Membership/LOGOS/autoware.svg"
+    <img src="../Foundation/Membership/LOGOS/autoware.svg"
     style="width: 15%; float:right"
     alt="Autoware Foundation" />
   </a>
   <p>
-  The seL4 Foundation welcomes <a href = "https://autoware.org/">the Autoware Foundation</a> as a <a href="/Foundation/Membership">member</a>.
+  The seL4 Foundation welcomes <a href = "https://autoware.org/">the Autoware Foundation</a> as a <a href="../Foundation/Membership">member</a>.
   </p>
   <p>
     The Autoware Foundation hosts the Autoware Project, the world’s leading open-source software project for autonomous driving.
@@ -623,7 +623,7 @@ layout: news
 </div>
 <div>
   <a href = "../Foundation/Summit/2023">
-    <img src="/images/sel4-summit-logo.svg"
+    <img src="../images/sel4-summit-logo.svg"
     style="width: 15%; float:right"
     alt="seL4 summit" />
   </a>
@@ -647,7 +647,7 @@ layout: news
 </div>
 <div>
     <a href = "../Foundation/Summit/2023">
-    <img src="/images/sel4-summit-logo.svg"
+    <img src="../images/sel4-summit-logo.svg"
     style="width: 15%; float:right"
     alt="seL4 summit" />
     </a>
@@ -659,7 +659,7 @@ layout: news
 <div class="people_grid">
   <div class="person">
     <div class="person_pic">
-      <a href="http://loonwerks.com/people/darren-cofer.html"><img src="../../../images/summit/darren.jpg" alt="Darren Cofer" width="80" /></a>
+      <a href="http://loonwerks.com/people/darren-cofer.html"><img src="../images/summit/darren.jpg" alt="Darren Cofer" width="80" /></a>
     </div>
     <div class="person_title">
       <strong><a href="http://loonwerks.com/people/darren-cofer.html">Darren Cofer
@@ -672,7 +672,7 @@ layout: news
 
   <div class="person">
     <div class="person_pic">
-      <a href="http://www.ikuz.org"><img src="../../../images/tsc/ihor.jpg" alt="Ihor Kuz" width="80" /></a>
+      <a href="http://www.ikuz.org"><img src="../images/tsc/ihor.jpg" alt="Ihor Kuz" width="80" /></a>
     </div>
     <div class="person_title">
       <strong><a href="http://www.ikuz.org">Ihor Kuz
@@ -686,7 +686,7 @@ layout: news
 
   <div class="person">
     <div class="person_pic">
-      <a href="https://perry.alexander.name"><img src="../../../images/summit/perry.jpg" alt="Perry Alexander" width="80"/></a>
+      <a href="https://perry.alexander.name"><img src="../images/summit/perry.jpg" alt="Perry Alexander" width="80"/></a>
     </div>
     <div class="person_title">
       <strong><a href="https://perry.alexander.name">Perry Alexander</a></strong>
@@ -710,7 +710,7 @@ layout: news
 
   <div class="person">
     <div class="person_pic">
-      <a href="https://galois.com/team/todd-carpenter/"><img src="../../../images/summit/todd.jpg" alt="Todd Carpenter" width="80"/></a>
+      <a href="https://galois.com/team/todd-carpenter/"><img src="../images/summit/todd.jpg" alt="Todd Carpenter" width="80"/></a>
     </div>
     <div class="person_title">
       <strong><a href="https://galois.com/team/todd-carpenter/">Todd Carpenter</a></strong>
@@ -722,7 +722,7 @@ layout: news
 
   <div class="person_no_link">
     <div class="person_pic">
-      <img src="../../../images/summit/alison.jpg" alt="Alison Felizzi" width="80"/>
+      <img src="../images/summit/alison.jpg" alt="Alison Felizzi" width="80"/>
     </div>
     <div class="person_title">
       <strong>Alison Felizzi</strong>
@@ -734,7 +734,7 @@ layout: news
 
   <div class="person">
     <div class="person_pic">
-      <a href="https://www.linkedin.com/in/axelheider"><img src="../../../images/summit/axel.png" alt="Axel Heider" width="80" /></a>
+      <a href="https://www.linkedin.com/in/axelheider"><img src="../images/summit/axel.png" alt="Axel Heider" width="80" /></a>
     </div>
     <div class="person_title">
       <strong><a href="https://www.linkedin.com/in/axelheider">Axel Heider</a></strong>
@@ -758,7 +758,7 @@ layout: news
 
   <div class="person_no_link">
     <div class="person_pic">
-      <img src="../../../images/summit/lucy.jpg" alt="Lucy Parker" width="80"/>
+      <img src="../images/summit/lucy.jpg" alt="Lucy Parker" width="80"/>
     </div>
     <div class="person_title">
       <strong>Lucy Parker</strong>
@@ -770,7 +770,7 @@ layout: news
 
   <div class="person">
     <div class="person_pic">
-      <a href="https://nickspinale.com"><img src="../../../images/summit/nick.jpg" alt="Nick Spinale" width="80"/></a>
+      <a href="https://nickspinale.com"><img src="../images/summit/nick.jpg" alt="Nick Spinale" width="80"/></a>
     </div>
     <div class="person_title">
       <strong><a href="https://nickspinale.com">Nick Spinale</a></strong>
@@ -782,7 +782,7 @@ layout: news
 
   <div class="person">
     <div class="person_pic">
-      <a href="https://www.linkedin.com/in/robbie-vanvossen-gr/"><img src="../../../images/summit/robbie.png" alt="Robbie VanVossen" width="80"/></a>
+      <a href="https://www.linkedin.com/in/robbie-vanvossen-gr/"><img src="../images/summit/robbie.png" alt="Robbie VanVossen" width="80"/></a>
     </div>
     <div class="person_title">
       <strong><a href="https://www.linkedin.com/in/robbie-vanvossen-gr/">Robbie VanVossen</a></strong>
@@ -795,7 +795,7 @@ layout: news
 
   <div class="person">
     <div class="person_pic">
-      <a href="https://www.ncsc.gov.uk/"><img src="../../../images/summit/person-pc.svg" alt="NCSC" width="80"/></a>
+      <a href="https://www.ncsc.gov.uk/"><img src="../images/summit/person-pc.svg" alt="NCSC" width="80"/></a>
     </div>
     <div class="person_title">
       <strong><a href="https://www.ncsc.gov.uk/">Martin (NCSC)</a></strong>
@@ -816,7 +816,7 @@ layout: news
 </div>
 <div>
     <a href = "../Foundation/Summit/2023">
-    <img src="/images/sel4-summit-logo.svg"
+    <img src="../images/sel4-summit-logo.svg"
     style="width: 15%; float:right"
     alt="seL4 summit" />
     </a>

--- a/news/2024.html
+++ b/news/2024.html
@@ -15,7 +15,7 @@ redirect_from: /news.html
  <p>
 
    <a href="https://www.rtx.com/">
-     <img src="/Foundation/Membership/LOGOS/raytheontechnologies.svg"
+     <img src="../Foundation/Membership/LOGOS/raytheontechnologies.svg"
 	  style="width: 20%;  padding-left:10px;  float:right"
 	  alt="Raytheon logo"/>
    </a>
@@ -37,7 +37,7 @@ redirect_from: /news.html
 </div>
 <div>
   <a href = "../Foundation/Summit/2024">
-    <img src="/images/summit/sel4_summit_2024.svg"
+    <img src="../images/summit/sel4_summit_2024.svg"
     style="width: 15%; float:right"
     alt="seL4 summit" />
   </a>
@@ -76,7 +76,7 @@ redirect_from: /news.html
 <div>
   <p>
     <a href="https://sel4.foundation">
-      <img src="/images/sel4-foundation-logo.svg" style="width: 15%;
+      <img src="../images/sel4-foundation-logo.svg" style="width: 15%;
 	   padding-left:10px; float:right" alt="seL4 Foundation logo" />
     </a>
     The seL4 Foundation is pleased to welcome <a href="https://www.apple.com/">Apple</a> as our latest <a href="../Foundation/Membership">member</a>.
@@ -95,7 +95,7 @@ redirect_from: /news.html
 <div>
  <p>
 
-   <img src="/images/Proof-FC.svg"
+   <img src="../images/Proof-FC.svg"
 	style="width: 20%;  padding-left:10px;  float:right"
 	alt="Functional correctness proof"/>
 
@@ -127,7 +127,7 @@ redirect_from: /news.html
 </div>
 <div>
   <a href = "../Foundation/Summit/2024">
-    <img src="/images/summit/sel4_summit_2024.svg"
+    <img src="../images/summit/sel4_summit_2024.svg"
     style="width: 15%; float:right"
     alt="seL4 summit" />
   </a>
@@ -155,7 +155,7 @@ redirect_from: /news.html
 </div>
 <div>
     <a href = "../Foundation/Summit/2024">
-    <img src="/images/summit/sel4_summit_2024.svg"
+    <img src="../images/summit/sel4_summit_2024.svg"
     style="width: 15%; float:right"
     alt="seL4 summit" />
     </a>
@@ -167,7 +167,7 @@ redirect_from: /news.html
     <div class="people_grid">
     <div class="person">
       <div class="person_pic">
-        <a href="http://www.ikuz.org"><img src="../../../images/tsc/ihor.jpg" alt="Ihor Kuz" width="80" /></a>
+        <a href="http://www.ikuz.org"><img src="../images/tsc/ihor.jpg" alt="Ihor Kuz" width="80" /></a>
       </div>
       <div class="person_title">
         <strong><a href="http://www.ikuz.org">Ihor Kuz
@@ -181,7 +181,7 @@ redirect_from: /news.html
 
     <div class="person">
       <div class="person_pic">
-        <a href="https://nickspinale.com"><img src="../../../images/summit/nick.jpg" alt="Nick Spinale" width="80"/></a>
+        <a href="https://nickspinale.com"><img src="../images/summit/nick.jpg" alt="Nick Spinale" width="80"/></a>
       </div>
       <div class="person_title">
         <strong><a href="https://nickspinale.com">Nick Spinale
@@ -195,7 +195,7 @@ redirect_from: /news.html
 
     <div class="person">
       <div class="person_pic">
-        <a href="https://www.ncsc.gov.uk/"><img src="../../../images/summit/person-pc.svg" alt="NCSC" width="80"/></a>
+        <a href="https://www.ncsc.gov.uk/"><img src="../images/summit/person-pc.svg" alt="NCSC" width="80"/></a>
       </div>
       <div class="person_title">
         <strong><a href="https://www.ncsc.gov.uk/">Adam (NCSC)</a></strong>
@@ -207,7 +207,7 @@ redirect_from: /news.html
 
     <div class="person">
       <div class="person_pic">
-        <a href="https://www.linkedin.com/in/alison-felizzi-991244189"><img src="../../../images/summit/alison.jpg" alt="Alison Felizzi" width="80"/></a>
+        <a href="https://www.linkedin.com/in/alison-felizzi-991244189"><img src="../images/summit/alison.jpg" alt="Alison Felizzi" width="80"/></a>
       </div>
       <div class="person_title">
         <strong><a href="https://www.linkedin.com/in/alison-felizzi-991244189">Alison Felizzi</a></strong>
@@ -219,7 +219,7 @@ redirect_from: /news.html
 
   <div class="person">
       <div class="person_pic">
-        <a href="https://loonwerks.com/people/david-hardin.html"><img src="../../../images/summit/RTX-David.png" alt="David Hardin" width="80"/></a>
+        <a href="https://loonwerks.com/people/david-hardin.html"><img src="../images/summit/RTX-David.png" alt="David Hardin" width="80"/></a>
       </div>
       <div class="person_title">
         <strong><a href="https://loonwerks.com/people/david-hardin.html">David Hardin</a></strong>
@@ -231,7 +231,7 @@ redirect_from: /news.html
 
   <div class="person">
       <div class="person_pic">
-        <a href="https://evermatos.com/"><img src="../../../images/summit/everton.jpg" alt="Everton de Matos" width="80"/></a>
+        <a href="https://evermatos.com/"><img src="../images/summit/everton.jpg" alt="Everton de Matos" width="80"/></a>
       </div>
       <div class="person_title">
         <strong><a href="https://evermatos.com/">Everton de Matos</a></strong>
@@ -255,7 +255,7 @@ redirect_from: /news.html
 
     <div class="person_no_link">
       <div class="person_pic">
-        <img src="../../../images/summit/indan.jpg" alt="Indan Zupancic" width="80"/>
+        <img src="../images/summit/indan.jpg" alt="Indan Zupancic" width="80"/>
       </div>
       <div class="person_title">
         <strong>Indan Zupancic</strong>
@@ -264,7 +264,7 @@ redirect_from: /news.html
 
     <div class="person">
       <div class="person_pic">
-        <a href="https://www.cs.ksu.edu/about/people/faculty/hatcliff/"><img src="../../../images/summit/john-h.jpg" alt="John Hatcliff" width="80"/></a>
+        <a href="https://www.cs.ksu.edu/about/people/faculty/hatcliff/"><img src="../images/summit/john-h.jpg" alt="John Hatcliff" width="80"/></a>
       </div>
       <div class="person_title">
         <strong><a href="https://www.cs.ksu.edu/about/people/faculty/hatcliff/">John Hatcliff</a></strong>
@@ -277,7 +277,7 @@ redirect_from: /news.html
     <div class="person">
       <div class="person_pic">
         <a href="https://www.linkedin.com/in/lucy-parker-13a484253/">
-        <img src="../../../images/summit/lucy.jpg" alt="Lucy Parker" width="80"/></a>
+        <img src="../images/summit/lucy.jpg" alt="Lucy Parker" width="80"/></a>
       </div>
       <div class="person_title">
         <strong><a href="https://www.linkedin.com/in/lucy-parker-13a484253/">Lucy Parker</a></strong>
@@ -286,7 +286,7 @@ redirect_from: /news.html
 
     <div class="person">
       <div class="person_pic">
-        <a href="https://www.linkedin.com/in/mbrcknl/"><img src="../../../images/summit/matthew.jpg" alt="Matthew Brecknell" width="80"/></a>
+        <a href="https://www.linkedin.com/in/mbrcknl/"><img src="../images/summit/matthew.jpg" alt="Matthew Brecknell" width="80"/></a>
       </div>
       <div class="person_title">
         <strong><a href="https://www.linkedin.com/in/mbrcknl/">Matthew Brecknell</a></strong>
@@ -299,7 +299,7 @@ redirect_from: /news.html
     <div class="person">
       <div class="person_pic">
         <a href="https://galois.com/team/michal-podhradsky/
-  "><img src="../../../images/summit/michal.jpg" alt="Michal Podhradsky" width="80"/></a>
+  "><img src="../images/summit/michal.jpg" alt="Michal Podhradsky" width="80"/></a>
       </div>
       <div class="person_title">
         <strong><a href="https://galois.com/team/michal-podhradsky/">Michal Podhradsky</a></strong>
@@ -311,7 +311,7 @@ redirect_from: /news.html
 
     <div class="person">
       <div class="person_pic">
-        <a href="https://www.linkedin.com/in/robbie-vanvossen-gr/"><img src="../../../images/summit/robbie.png" alt="Robbie VanVossen" width="80"/></a>
+        <a href="https://www.linkedin.com/in/robbie-vanvossen-gr/"><img src="../images/summit/robbie.png" alt="Robbie VanVossen" width="80"/></a>
       </div>
       <div class="person_title">
         <strong><a href="https://www.linkedin.com/in/robbie-vanvossen-gr/">Robbie VanVossen</a></strong>
@@ -331,7 +331,7 @@ redirect_from: /news.html
 </div>
 <div>
   <a href = "../Foundation/Summit/2024">
-    <img src="/images/summit/sel4_summit_2024.svg"
+    <img src="../images/summit/sel4_summit_2024.svg"
     style="width: 15%; float:right"
     alt="seL4 summit" />
   </a>
@@ -348,7 +348,7 @@ redirect_from: /news.html
     We will announce a Call for Presentations in the coming weeks. Stay tuned!
   </p>
   <div style="margin: auto; width: 100%;text-align:center">
-    <img src="/images/summit/sydney-harbour.jpg" alt="Sydney Harbour" />
+    <img src="../images/summit/sydney-harbour.jpg" alt="Sydney Harbour" />
   </div>
 </div>
 
@@ -360,7 +360,7 @@ redirect_from: /news.html
 </div>
 <div style="margin: auto; width: 100%;text-align:center">
     <a href = "https://www.linuxfoundation.org/hubfs/Reports/2023_lf_annual_report_122123a.pdf?hsLang=en">
-    <img src="/images/lf-annual-report-2023.png"
+    <img src="../images/lf-annual-report-2023.png"
     style="width: 70%;"
     alt="LF annual report" />
     </a>


### PR DESCRIPTION
This makes all manual links (a href and img src) on the site use relative paths, which should enable previews with varying path prefixes in the next step.
