### PR TITLE
github: remove preview when PR is closed

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,34 @@
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+---
+
+name: PR cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cleanup:
+    name: "Clean up PR preview"
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: seL4/website_pr_hosting
+          ssh-key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          ref: refs/heads/gh-pages
+
+      - name: Remove any potential PR directory in website_pr_hosting
+        run: |
+          git config --global user.name "seL4 CI"
+          git config --global user.email "ci@sel4.systems"
+          if [ -d "PR_${{ github.event.number }}" ]; then \
+            git rm -rf PR_${{ github.event.number }}; \
+            git commit -m "PR cleanup"; \
+            git push; \
+          else \
+            echo "Nothing to do";
+          fi


### PR DESCRIPTION
Avoid filling up the root directory in the `gh_pages` branch with hundreds of PR previews. When the PR is closed, the preview should no longer be needed.

The PRs will still accumulate in the repo history, but CI only ever pulls with depth 1, and we should never need to manually clone the repo.