### PR TITLE
news: fix html conversion accident

### DIFF
--- a/_news-items/2024-07-02-release.md
+++ b/_news-items/2024-07-02-release.md
@@ -7,16 +7,16 @@ img: /images/seL4.svg
 alt: seL4 logo
 ---
 
-It's been a long time coming -- we’re pleased to announce the release of
+It's been a long time coming -- we're pleased to announce the release of
 
 - [seL4 13.0.0](https://docs.sel4.systems/releases/sel4/13.0.0): The seL4
   microkernel
 - [Microkit 1.3.0](https://docs.sel4.systems/releases/microkit/1.3.0): The seL4
-  Microkit for building -tic-architecture systems
+  Microkit for building static-architecture systems
 - [CAmkES 3.11.0](https://docs.sel4.systems/releases/camkes/camkes-3.11.0):
-  Component Architecture for -rokernel-based Embedded Systems
+  Component Architecture for microkernel-based Embedded Systems
 - [capDL 0.3.0](https://docs.sel4.systems/releases/capdl/0.3.0): Tools for
-  generating, parsing and loading capability -tribution specifications
+  generating, parsing and loading capability distribution specifications
 - [rust-sel4 1.0.0](https://github.com/seL4/rust-sel4/releases/tag/v1.0.0): Rust
   support for seL4 userspace. See
   [seL4/rust-sel4](https://github.com/seL4/rust-sel4/) on GitHub for more


### PR DESCRIPTION
This was one of the early files and it looks like some of the line breaks got scrambled in the html-to-md conversion.

(I haven't seen that kind of effect on the other converted news items)