### PR TITLE
Add served-by-seL4 footer to mobile pages

### DIFF
--- a/_includes/footer_icons.html
+++ b/_includes/footer_icons.html
@@ -1,0 +1,3 @@
+<a href="https://fosstodon.org/@sel4"><img style="height:36px; padding-right:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/mastodon.svg" | relative_url }} alt="mastodon icon"></a>
+<a href="https://www.youtube.com/@seL4"><img style="height:36px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/youtube.svg" | relative_url }} alt="youtube icon"></a>
+<a href="https://www.linkedin.com/company/sel4"><img style="height:36px; padding-left:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/linkedin.svg" | relative_url }} alt="linkedin icon"></a>

--- a/_includes/footer_icons.html
+++ b/_includes/footer_icons.html
@@ -1,3 +1,7 @@
+<!--
+Copyright 2024 seL4 Project a Series of LF Projects, LLC.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 <a href="https://fosstodon.org/@sel4"><img style="height:36px; padding-right:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/mastodon.svg" | relative_url }} alt="mastodon icon"></a>
 <a href="https://www.youtube.com/@seL4"><img style="height:36px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/youtube.svg" | relative_url }} alt="youtube icon"></a>
 <a href="https://www.linkedin.com/company/sel4"><img style="height:36px; padding-left:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/linkedin.svg" | relative_url }} alt="linkedin icon"></a>

--- a/_includes/footer_text.html
+++ b/_includes/footer_text.html
@@ -1,3 +1,7 @@
+<!--
+Copyright 2024 seL4 Project a Series of LF Projects, LLC.
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 {% if site.on_seL4 %}
 <a href="/Info/Website/">About this web server</a>
 Served by <a href="https://micropython.org/">MicroPython</a>

--- a/_includes/footer_text.html
+++ b/_includes/footer_text.html
@@ -1,0 +1,13 @@
+{% if site.on_seL4 %}
+<a href="/Info/Website/">About this web server</a>
+Served by <a href="https://micropython.org/">MicroPython</a>
+on <a href="https://lionsos.org/"> LionsOS</a> on seL4.
+<br/>
+{% endif %}
+Copyright &copy; 2024 seL4 Project a Series of LF Projects, LLC.<br/>
+seL4 is a trademark of LF Projects, LLC.<br/>
+For trademark usage guidelines, privacy and cookie policies,
+and other applicable policies, as well as terms and conditions
+governing this web site, please see
+<a href="http://www.lfprojects.org/">www.lfprojects.org</a>
+and the <a href={{ "/Foundation/Trademark/" | relative_url }}>trademark guidelines</a>.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -75,46 +75,18 @@
   <div class="container">
     <!-- for mobile screens -->
     <div class="text-center visible-xs">
-    <a href="https://fosstodon.org/@sel4"><img style="height:36px; padding-right:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/mastodon.svg" | relative_url }} alt="mastodon icon"></a>
-      <a href="https://www.youtube.com/@seL4"><img style="height:36px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/youtube.svg" | relative_url }} alt="youtube icon"></a>
-      <a href="https://www.linkedin.com/company/sel4"><img style="height:36px; padding-left:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/linkedin.svg" | relative_url }} alt="linkedin icon"></a>
+      {% include footer_icons.html %}
       <br>
       <br>
-{% if site.on_seL4 %}
-  <a href="/Info/Website/">About this web server</a>
-  Served by <a href="https://micropython.org/">MicroPython</a>
-on <a href="https://lionsos.org/"> LionsOS</a> on seL4.
-<br/>
-{% endif %}
-    Copyright &copy; 2024 seL4 Project a Series of LF Projects, LLC.<br/>
-      seL4 is a trademark of LF Projects, LLC.<br/>
-      For trademark usage guidelines, privacy and cookie policies,
-      and other applicable policies, as well as terms and conditions
-      governing this web site, please see
-      <a href="http://www.lfprojects.org/">www.lfprojects.org</a>
-      and the <a href={{ "/Foundation/Trademark/" | relative_url }}>trademark guidelines</a>.
+      {% include footer_text.html %}
     </div>
     <div class="row">
       <!-- for screens larger than mobiles -->
       <div class="col-xs-6 hidden-xs">
-{% if site.on_seL4 %}
-  <a href="/Info/Website/">About this web server</a>
-  Served by <a href="https://micropython.org/">MicroPython</a>
-on <a href="https://lionsos.org/"> LionsOS</a> on seL4.
-<br/>
-{% endif %}
-        Copyright &copy; 2024 seL4 Project a Series of LF Projects, LLC.<br/>
-        seL4 is a trademark of LF Projects, LLC.<br/>
-        For trademark usage guidelines, privacy and cookie policies,
-        and other applicable policies, as well as terms and conditions
-        governing this web site, please see
-        <a href="http://www.lfprojects.org/">www.lfprojects.org</a>
-        and the <a href={{ "/Foundation/Trademark/" | relative_url }}>trademark guidelines</a>.
+        {% include footer_text.html %}
       </div>
       <div class="col-xs-6 text-right hidden-xs">
-        <a href="https://fosstodon.org/@sel4"><img style="height:36px; padding-right:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/mastodon.svg" | relative_url }} alt="mastodon icon"></a>
-        <a href="https://www.youtube.com/@seL4"><img style="height:36px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/youtube.svg" | relative_url }} alt="youtube icon"></a>
-        <a href="https://www.linkedin.com/company/sel4"><img style="height:36px; padding-left:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/linkedin.svg" | relative_url }} alt="linkedin icon"></a>
+        {% include footer_icons.html %}
       </div>
     </div>
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -80,6 +80,12 @@
       <a href="https://www.linkedin.com/company/sel4"><img style="height:36px; padding-left:5px; padding-top:2px; padding-bottom:2px;" src={{ "/images/icons/linkedin.svg" | relative_url }} alt="linkedin icon"></a>
       <br>
       <br>
+{% if site.on_seL4 %}
+  <a href="/Info/Website/">About this web server</a>
+  Served by <a href="https://micropython.org/">MicroPython</a>
+on <a href="https://lionsos.org/"> LionsOS</a> on seL4.
+<br/>
+{% endif %}
     Copyright &copy; 2024 seL4 Project a Series of LF Projects, LLC.<br/>
       seL4 is a trademark of LF Projects, LLC.<br/>
       For trademark usage guidelines, privacy and cookie policies,


### PR DESCRIPTION
This footer was previously only enabled on the desktop version of the site.