### PR TITLE
fix broken links

### DIFF
--- a/About/index.html
+++ b/About/index.html
@@ -92,7 +92,7 @@ redirect_from:
   automotive, aviation, infrastructure, medical, and defence. A key
   highlight demonstrating its fit for real-world deployment was in
   the DARPA-funded <a href=
-  "http://trustworthy.systems/projects/TS/SMACCM/">HACMS</a>
+  "https://trustworthy.systems/projects/OLD/SMACCM/">HACMS</a>
   program, where seL4 was used to protect an autonomous helicopter
   against cyber-attacks. TS continues to push the state of the art
   of operating systems through <a href=

--- a/Learn/index.html
+++ b/Learn/index.html
@@ -36,8 +36,7 @@ redirect_from: /Learn/home.pml
 <p>
   If you prefer unstructured learning and want to dive in and explore
   on your own then follow the links on the
-  docsite's <a href="https://docs.sel4.systems/GettingStarted.html">Getting
-    Started</a> page.
+  docsite's <a href="https://docs.sel4.systems/Resources">Resources</a> page.
 </p>
 
 <p>

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ HTMLPROOFEROPT += --enforce-https=false --only-4xx --disable-external=false
 # comma-separated list of URL regexps, e.g. /twitter.com/,/facebook.com/
 # twitter ignored because of rate limiting; query links on github work, but don't seem to check
 # rtx.com produces 403 from GitHub
-HTMLPROOFEROPT += --ignore-urls '/twitter.com/,/flaticon.com/,/github.com.seL4.rfcs.pulls\?q/,/rtx.com/'
+HTMLPROOFEROPT += --ignore-urls '/twitter.com/,/flaticon.com/,/github.com.seL4.rfcs.pulls\?q/,/rtx.com/,/www.collinsaerospace.com/'
 
 checklinks:
 	@bundle exec htmlproofer $(HTMLPROOFEROPT) _site

--- a/_news-items/2021-08-13-defcon.html
+++ b/_news-items/2021-08-13-defcon.html
@@ -6,7 +6,7 @@ anchor: defcon
 ---
 
 <p>
-  <a href="https://trustworthy.systems/projects/TS/SMACCM/">
+  <a href="https://trustworthy.systems/projects/OLD/SMACCM/">
     <img src="../images/smaccmcopter-defcon.jpg" style="width: 50%;  padding-left:10px;  float:right"
       alt="SMACCMcopter at DEF CON" />
   </a>
@@ -16,9 +16,9 @@ anchor: defcon
   to <a href="https://defcon.org/html/defcon-29/dc-29-index.html">DEF&nbsp;CON</a>
   and invited the assembled hacker elite to attack it. The
   SMACCMcopter was the <em>research vehicle</em> of the Air Team at
-  DARPA's <a href="https://www.darpa.mil/program/high-assurance-cyber-military-systems">HACMS</a>
+  DARPA's <a href="https://www.darpa.mil/research/programs/high-assurance-cyber-military-systems">HACMS</a>
   program. The Trustworthy Systems
-  team <a href="https://trustworthy.systems/projects/TS/SMACCM/">worked
+  team <a href="https://trustworthy.systems/projects/OLD/SMACCM/">worked
     with project partners</a> to deploy seL4 and leverage formal
   methods to protect the drone from cyber attacks.
 </p>


### PR DESCRIPTION
- TS has moved HACMS page
- DARPA has moved HACMS page
- GettingStarted was renamed to Resources on docsite
- exclude collinsaerospace.com from link check, because it thinks a link check is DOS