### PR TITLE
set up .ignore file for link checker

### DIFF
--- a/.linkcheck-ignore.yml
+++ b/.linkcheck-ignore.yml
@@ -1,0 +1,15 @@
+# Copyright Proofcraft Pty Ltd
+# SPDX-License-Identifier: BSD-2-Clause
+
+files:
+  - vendor
+  - node_modules
+  - "_.*/.*"
+  - ".*html"
+
+urls:
+  - twitter.com
+  - flaticon.com
+  - github.com.seL4.rfcs.pulls\?q
+  - rtx.com
+  - www.collinsaerospace.com


### PR DESCRIPTION
The Makefile should eventually draw its list of ignored URLs from here.

We currently ignore all .html files and all files in `_` directories, because the separate website link check takes care of these. This leaves mostly the README.md file for now.

This will work with https://github.com/seL4/ci-actions/pull/390