### PR TITLE
github: avoid echo for writing known_hosts

### DIFF
--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -63,7 +63,7 @@ jobs:
           ssh-private-key: ${{ secrets.WEB_DEPLOY_KEY }}
       - name: Add host keys
         run: |
-          echo ${{ secrets.WEB_HOST_KEYS }} > ~/.ssh/known_hosts
+          cat > ~/.ssh/known_hosts <<< ${{ secrets.WEB_HOST_KEYS }}
       - name: rsync
         run: |
           rsync -a --delete -e 'ssh -J web-updater@login.trustworthy.systems' _site_on_seL4/ web-updater@tftp.keg.cse.unsw.edu.au:/vmm-work/www
@@ -88,7 +88,7 @@ jobs:
           ssh-private-key: ${{ secrets.WEB_DEPLOY_KEY }}
       - name: Add host keys
         run: |
-          echo ${{ secrets.WEB_HOST_KEYS }} > ~/.ssh/known_hosts
+          cat > ~/.ssh/known_hosts <<< ${{ secrets.WEB_HOST_KEYS }}
       - name: rsync
         run: |
           rsync -a --delete _site/ web-updater@lists.sel4.systems:/var/www/html/seL4


### PR DESCRIPTION
Use `<<<` to write the known hosts variable into the file. The `echo` method doesn't deal well with newlines.