### PR TITLE
Gemfile.lock: add current darwin version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-23
   x86_64-linux
 


### PR DESCRIPTION
Installing the gems on current darwin-24 (sequoia) will modify the Gemfile.lock file to include the architecture, even though no other content changes.