### PR TITLE
Small website fixes

### DIFF
--- a/Contribute/git-conventions.md
+++ b/Contribute/git-conventions.md
@@ -73,9 +73,9 @@ Examples and counter-examples of the above rules can be found in the git commit
 * Commits should make the changes easier to follow: if you move a function and change it, please do
   so in separate commits.
 {: .list-tick .my-0}
-* Commits should be separated into functional, logical changes, unless those changes are dependant.
-  if you find yourself writing a commit message which says 'Fix X and clean up Y', you should
-      probably use two commits.
+* Commits should be separated into functional, logical changes. If you find
+  yourself writing a commit message which says 'Fix X and clean up Y', you
+  should probably use two commits.
 {: .list-tick .my-0}
 
 ## Further resources

--- a/_includes/green-roadmap-li.html
+++ b/_includes/green-roadmap-li.html
@@ -5,7 +5,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 <li class="flex flex-row mt-8 mx-0">
   {% svg _icons/map-pin.svg class="h-10 w-10 sm:h-15 sm:w-15 flex-none text-f_green-600" %}
   <div class="ml-2 sm:ml-4">
-    <div><strong>{{include.title}}</strong>:</div>
+    <div class="text-dark"><strong>{{include.title}}</strong>:</div>
     <div class="text-light">
       {{include.description}}
     </div>

--- a/_news-items/9999-12-31-template.md
+++ b/_news-items/9999-12-31-template.md
@@ -13,10 +13,16 @@ alt: seL4 logo
 link: https://sel4.systems
 
 # usually unused:
-# optional: width of the image; default 20%
-width: 20%
+# optional: no forced white background for the image.
+#           Use for images with transparent background that work in dark mode.
+# dark: true
+# optional: image width; default: w-2/5
+# img_w: "w-3/10"
+# optional: css class for the image; overrides dark/img_w;
+#           default: "bg-white p-6 sm:p-8 w-2/5"
+# img_class: "w-3/10 p-0"
 # optional: id of the link anchor; only needed for older items; default: mm-dd
-anchor: big-news
+# anchor: big-news
 ---
 
 Markdown or html content of the news text. Save as `.md` if using markdown, and


### PR DESCRIPTION
- remove typo/unclear side sentence in git-conventions
- fix dark mode title for roadmap items
- news template: document new parameters
