### PR TITLE
generate performance page in jekyll

### DIFF
--- a/_data/benchmarks.json
+++ b/_data/benchmarks.json
@@ -47,10 +47,6 @@
       "name"
     ],
     [
-      "Clock",
-      "clock"
-    ],
-    [
       "Compiler",
       "compiler"
     ],
@@ -69,9 +65,9 @@
         "name": "A9/i.MX6/Sabre",
         "clock": "1.0 GHz",
         "compiler": "arm-linux-gnueabi-gcc GNU 10.2.1",
-        "ipc": [
-          594,
-          13
+        "irq": [
+          590,
+          14
         ],
         "call": [
           316,
@@ -79,11 +75,11 @@
         ],
         "reply": [
           334,
-          2
+          1
         ],
         "notify": [
-          850,
-          13
+          859,
+          17
         ],
         "build_command": "init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DAARCH32=TRUE -DPLATFORM=sabre"
       },
@@ -95,21 +91,21 @@
         "name": "i7-4770/Haswell",
         "clock": "3.4 GHz",
         "compiler": "gcc GNU 10.2.1",
-        "ipc": [
-          1568,
-          262
+        "irq": [
+          1640,
+          255
         ],
         "call": [
-          594,
-          15
+          593,
+          13
         ],
         "reply": [
-          605,
-          15
+          593,
+          13
         ],
         "notify": [
-          1324,
-          7
+          1323,
+          5
         ],
         "build_command": "init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DPLATFORM=x86_64"
       },
@@ -119,24 +115,24 @@
         "isa": "x86_64",
         "mode": 64,
         "name": "i7-6700/Skylake",
-        "note": "(without meltdown mitigation)",
+        "note": "without meltdown mitigation",
         "clock": "3.4 GHz",
         "compiler": "gcc GNU 10.2.1",
-        "ipc": [
-          1517,
-          193
+        "irq": [
+          1472,
+          200
         ],
         "call": [
           385,
-          3
+          4
         ],
         "reply": [
-          380,
-          3
+          383,
+          4
         ],
         "notify": [
-          768,
-          9
+          749,
+          11
         ],
         "build_command": "init-build.sh -DKernelSkimWindow=FALSE -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DPLATFORM=x86_64"
       },
@@ -148,21 +144,21 @@
         "name": "A57/Tx1/Jetson",
         "clock": "1.9 GHz",
         "compiler": "aarch64-linux-gnu-gcc GNU 10.2.1",
-        "ipc": [
+        "irq": [
           736,
           6
         ],
         "call": [
-          408,
-          11
+          405,
+          9
         ],
         "reply": [
           416,
-          0
+          1
         ],
         "notify": [
-          936,
-          7
+          881,
+          11
         ],
         "build_command": "init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DAARCH64=TRUE -DPLATFORM=tx1"
       },
@@ -174,21 +170,21 @@
         "name": "U54-MC/SiFive Freedom U540/Hifive",
         "clock": "1.5 GHz",
         "compiler": "riscv64-unknown-elf-gcc GNU 8.3.0",
-        "ipc": [
-          1001,
-          37
+        "irq": [
+          1039,
+          89
         ],
         "call": [
-          803,
-          85
+          813,
+          91
         ],
         "reply": [
-          826,
-          73
+          830,
+          85
         ],
         "notify": [
-          1526,
-          81
+          1697,
+          78
         ],
         "build_command": "init-build.sh -DFASTPATH=TRUE -DHARDWARE=FALSE -DFAULT=FALSE -DRISCV64=TRUE -DPLATFORM=hifive"
       }
@@ -202,8 +198,8 @@
         "name": "A9/i.MX6/Sabre",
         "clock": "1.0 GHz",
         "compiler": "arm-linux-gnueabi-gcc GNU 10.2.1",
-        "ipc": [
-          775,
+        "irq": [
+          773,
           13
         ],
         "call": [
@@ -215,7 +211,7 @@
           2
         ],
         "notify": [
-          1153,
+          1145,
           13
         ],
         "build_command": "init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DAARCH32=TRUE -DPLATFORM=sabre -DMCS=TRUE"
@@ -228,21 +224,21 @@
         "name": "i7-4770/Haswell",
         "clock": "3.4 GHz",
         "compiler": "gcc GNU 10.2.1",
-        "ipc": [
-          1956,
-          415
+        "irq": [
+          1999,
+          418
         ],
         "call": [
-          599,
-          17
+          606,
+          13
         ],
         "reply": [
-          603,
+          602,
           12
         ],
         "notify": [
-          1571,
-          11
+          1573,
+          14
         ],
         "build_command": "init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DPLATFORM=x86_64 -DMCS=TRUE"
       },
@@ -252,24 +248,24 @@
         "isa": "x86_64",
         "mode": 64,
         "name": "i7-6700/Skylake",
-        "note": "(without meltdown mitigation)",
+        "note": "without meltdown mitigation",
         "clock": "3.4 GHz",
         "compiler": "gcc GNU 10.2.1",
-        "ipc": [
+        "irq": [
           1824,
-          333
+          322
         ],
         "call": [
-          390,
-          3
+          388,
+          2
         ],
         "reply": [
-          417,
-          6
+          414,
+          7
         ],
         "notify": [
           1054,
-          13
+          9
         ],
         "build_command": "init-build.sh -DKernelSkimWindow=FALSE -DMCS=TRUE -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DPLATFORM=x86_64"
       },
@@ -281,9 +277,9 @@
         "name": "A57/Tx1/Jetson",
         "clock": "1.9 GHz",
         "compiler": "aarch64-linux-gnu-gcc GNU 10.2.1",
-        "ipc": [
-          925,
-          66
+        "irq": [
+          932,
+          72
         ],
         "call": [
           419,
@@ -294,8 +290,8 @@
           2
         ],
         "notify": [
-          1023,
-          11
+          1021,
+          25
         ],
         "build_command": "init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DAARCH64=TRUE -DPLATFORM=tx1 -DMCS=TRUE"
       },
@@ -307,24 +303,25 @@
         "name": "U54-MC/SiFive Freedom U540/Hifive",
         "clock": "1.5 GHz",
         "compiler": "riscv64-unknown-elf-gcc GNU 8.3.0",
-        "ipc": [
-          3348,
-          89
+        "irq": [
+          3373,
+          121
         ],
         "call": [
-          711,
-          110
+          677,
+          20
         ],
         "reply": [
-          731,
-          51
+          747,
+          84
         ],
         "notify": [
-          4256,
-          227
+          4211,
+          161
         ],
         "build_command": "init-build.sh -DFASTPATH=TRUE -DHARDWARE=FALSE -DFAULT=FALSE -DRISCV64=TRUE -DPLATFORM=hifive -DMCS=TRUE"
       }
     ]
-  }
+  },
+  "sha": "4cf8e02"
 }

--- a/_includes/bench-comp-table.html
+++ b/_includes/bench-comp-table.html
@@ -1,0 +1,35 @@
+{%- comment %}
+Copyright 2025 seL4 Project a Series of LF Projects, LLC.
+SPDX-License-Identifier: CC-BY-SA-4.0
+{% endcomment -%}
+{%- assign cols = site.data.benchmarks.comp_cols -%}
+{%- assign data = site.data.benchmarks.data[include.section] -%}
+<h3 class="h3-size text-dark mt-12 mb-6 max-w-4xl mx-auto">{{include.section}}</h3>
+<div class="w-full overflow-x-auto">
+  <table class="data-table">
+    <thead>
+      <tr>
+        {%- for col in cols %}
+        <th scope="col">{{ col[0] }}</th>
+        {%- endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {%- for row in data %}
+      <tr>
+        {%- for col in cols %}
+        {%-   assign key = col[1] %}
+        {%-   if key == "mode" %}
+        {%-     assign class="data-table-right" %}
+        {%-   elsif key == "build_command" %}
+        {%-     assign class="monospace" %}
+        {%-   else %}
+        {%-     assign class="" %}
+        {%-   endif %}
+        <td class="{{class}}">{{ row[key] }}</td>
+        {%- endfor %}
+      </tr>
+      {%- endfor %}
+    </tbody>
+  </table>
+</div>

--- a/_includes/benchmark-table.html
+++ b/_includes/benchmark-table.html
@@ -1,0 +1,50 @@
+{%- comment %}
+Copyright 2025 seL4 Project a Series of LF Projects, LLC.
+SPDX-License-Identifier: CC-BY-SA-4.0
+{% endcomment -%}
+{%- assign cols = site.data.benchmarks.data_cols -%}
+{%- assign data = site.data.benchmarks.data[include.section] -%}
+<div class="max-w-4xl mx-auto">
+  <h3 class="h3-size text-dark mt-12 mb-6">{{include.section}}</h3>
+  <div class="w-full overflow-x-auto">
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th scope="col" class="w-[8ex]" colspan="1">{{ cols[0][0] }}</th>
+          <th scope="col" class="text-center w-[4ex]" colspan="1">{{ cols[1][0] }}</th>
+          <th scope="col" class="w-2/5" colspan="1">{{ cols[2][0] }}</th>
+          <th scope="col" class="text-center w-[8ex]" colspan="1">{{ cols[3][0] }}</th>
+          <th scope="col" class="text-center" colspan="2">{{ cols[5][0] }}</th>
+          <th scope="col" class="text-center" colspan="2">{{ cols[4][0] }}</th>
+          <th scope="col" class="text-center" colspan="2">{{ cols[6][0] }}</th>
+          <th scope="col" class="text-center" colspan="2">{{ cols[7][0] }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {%- for row in data %}
+        <tr>
+          <td>{{row.isa}}</td>
+          <td class="data-table-right">{{row.mode}}</td>
+          <td>{{row.name}}{% if row.note %}<sup>*</sup>{% endif %}</td>
+          <td class="data-table-right">{{row.clock}}</td>
+          <td class="data-mean">{{row.irq[0]}}</td>
+          <td class="data-stddev">({{row.irq[1]}})</td>
+          <td class="data-mean">{{row.call[0]}}</td>
+          <td class="data-stddev">({{row.call[1]}})</td>
+          <td class="data-mean">{{row.reply[0]}}</td>
+          <td class="data-stddev">({{row.reply[1]}})</td>
+          <td class="data-mean">{{row.notify[0]}}</td>
+          <td class="data-stddev">({{row.notify[1]}})</td>
+        </tr>
+        {%- endfor %}
+      </tbody>
+    </table>
+  </div>
+  {%- for row in data %}
+  {%- if row.note %}
+  <p class="text-light text-xs sm:text-sm mt-4">
+    <sup>*</sup> {{row.note}}
+  </p>
+  {%- endif %}
+  {%- endfor %}
+</div>

--- a/performance.html
+++ b/performance.html
@@ -69,187 +69,21 @@ The following times are reported as mean and standard deviation in
 the format <em>mean (std dev)</em>, both rounded to the nearest integer.</p>
 
 <ul>
-  <li><strong>IRQ invoke</strong>: Time in cycles to invoke a user-level interrupt handler running in a different
-    address space as the interrupted thread.</li>
-  <li><strong>IPC call</strong>: Time in cycles for invoking a server in a different address space on the same core.
-  </li>
-  <li><strong>IPC reply</strong>: Time in cycles for a server replying to a client in a different address space on
-    the same core.</li>
-  <li><strong>Notify</strong>: Time in cycles to send a signal from a process with priority 1 to a higher
-    priority (255) process in a different address space</li>
+  <li><strong>IRQ invoke</strong>: Time in cycles to invoke a user-level
+    interrupt handler running in a different address space as the interrupted
+    thread.</li>
+  <li><strong>IPC call</strong>: Time in cycles for invoking a server in a
+    different address space on the same core.</li>
+  <li><strong>IPC reply</strong>: Time in cycles for a server replying to a
+    client in a different address space on the same core.</li>
+  <li><strong>Notify</strong>: Time in cycles to send a signal from a process
+    with priority 1 to a higher priority (255) process in a different address
+    space</li>
 </ul>
 </div>
 
-<!-- FIXME: read all of this from a json file instead -->
-<div class="max-w-4xl mx-auto">
-<h3 class="h3-size text-dark mt-12 mb-6">Default</h3>
-
-<div class="w-full overflow-x-auto">
-<table class="data-table">
-  <tr>
-    <th style=" width: 8ex;" colspan="1">ISA</th>
-    <th style="text-align: center; width: 4ex;" colspan="1">Mode</th>
-    <th style=" width: 40%;" colspan="1">Core/SoC/Board</th>
-    <th style="text-align: center; width: 8ex;" colspan="1">Clock</th>
-    <th style="text-align: center;" colspan="2">IRQ Invoke</th>
-    <th style="text-align: center;" colspan="2">IPC call</th>
-    <th style="text-align: center;" colspan="2">IPC reply</th>
-    <th style="text-align: center;" colspan="2">Notify</th>
-  </tr>  <tr>
-    <td>Armv7a</td>
-    <td class="data-table-right">32</td>
-    <td>A9/i.MX6/Sabre</td>
-    <td class="data-table-right">1.0 GHz</td>
-    <td class="data-mean">590</td>
-    <td class="data-stddev">(14)</td>
-    <td class="data-mean">316</td>
-    <td class="data-stddev">(2)</td>
-    <td class="data-mean">334</td>
-    <td class="data-stddev">(1)</td>
-    <td class="data-mean">859</td>
-    <td class="data-stddev">(17)</td>
-  </tr>  <tr>
-    <td>x86_64</td>
-    <td class="data-table-right">64</td>
-    <td>i7-4770/Haswell</td>
-    <td class="data-table-right">3.4 GHz</td>
-    <td class="data-mean">1640</td>
-    <td class="data-stddev">(255)</td>
-    <td class="data-mean">593</td>
-    <td class="data-stddev">(13)</td>
-    <td class="data-mean">593</td>
-    <td class="data-stddev">(13)</td>
-    <td class="data-mean">1323</td>
-    <td class="data-stddev">(5)</td>
-  </tr>  <tr>
-    <td>x86_64</td>
-    <td class="data-table-right">64</td>
-    <td>i7-6700/Skylake<sup>*</sup></td>
-    <td class="data-table-right">3.4 GHz</td>
-    <td class="data-mean">1472</td>
-    <td class="data-stddev">(200)</td>
-    <td class="data-mean">385</td>
-    <td class="data-stddev">(4)</td>
-    <td class="data-mean">383</td>
-    <td class="data-stddev">(4)</td>
-    <td class="data-mean">749</td>
-    <td class="data-stddev">(11)</td>
-  </tr>  <tr>
-    <td>Armv8a</td>
-    <td class="data-table-right">64</td>
-    <td>A57/Tx1/Jetson</td>
-    <td class="data-table-right">1.9 GHz</td>
-    <td class="data-mean">736</td>
-    <td class="data-stddev">(6)</td>
-    <td class="data-mean">405</td>
-    <td class="data-stddev">(9)</td>
-    <td class="data-mean">416</td>
-    <td class="data-stddev">(1)</td>
-    <td class="data-mean">881</td>
-    <td class="data-stddev">(11)</td>
-  </tr>  <tr>
-    <td>RV64IMAC</td>
-    <td class="data-table-right">64</td>
-    <td>U54-MC/SiFive Freedom U540/Hifive</td>
-    <td class="data-table-right">1.5 GHz</td>
-    <td class="data-mean">1039</td>
-    <td class="data-stddev">(89)</td>
-    <td class="data-mean">813</td>
-    <td class="data-stddev">(91)</td>
-    <td class="data-mean">830</td>
-    <td class="data-stddev">(85)</td>
-    <td class="data-mean">1697</td>
-    <td class="data-stddev">(78)</td>
-  </tr></table>
-  </div>
-
-  <p class="text-light text-xs sm:text-sm mt-4">
-  <sup>*</sup> without meltdown mitigation
-  </p>
-
-<h3 class="h3-size text-dark mt-12 mb-6">MCS</h3>
-<div class="w-full overflow-x-auto">
-  <table class="data-table">
-  <tr>
-    <th style=" width: 8ex;" colspan="1">ISA</th>
-    <th style="text-align: center; width: 4ex;" colspan="1">Mode</th>
-    <th style=" width: 40%;" colspan="1">Core/SoC/Board</th>
-    <th style="text-align: center; width: 8ex;" colspan="1">Clock</th>
-    <th style="text-align: center;" colspan="2">IRQ Invoke</th>
-    <th style="text-align: center;" colspan="2">IPC call</th>
-    <th style="text-align: center;" colspan="2">IPC reply</th>
-    <th style="text-align: center;" colspan="2">Notify</th>
-  </tr>  <tr>
-    <td>Armv7a</td>
-    <td class="data-table-right">32</td>
-    <td>A9/i.MX6/Sabre</td>
-    <td class="data-table-right">1.0 GHz</td>
-    <td class="data-mean">773</td>
-    <td class="data-stddev">(13)</td>
-    <td class="data-mean">325</td>
-    <td class="data-stddev">(2)</td>
-    <td class="data-mean">364</td>
-    <td class="data-stddev">(2)</td>
-    <td class="data-mean">1145</td>
-    <td class="data-stddev">(13)</td>
-  </tr>  <tr>
-    <td>x86_64</td>
-    <td class="data-table-right">64</td>
-    <td>i7-4770/Haswell</td>
-    <td class="data-table-right">3.4 GHz</td>
-    <td class="data-mean">1999</td>
-    <td class="data-stddev">(418)</td>
-    <td class="data-mean">606</td>
-    <td class="data-stddev">(13)</td>
-    <td class="data-mean">602</td>
-    <td class="data-stddev">(12)</td>
-    <td class="data-mean">1573</td>
-    <td class="data-stddev">(14)</td>
-  </tr>  <tr>
-    <td>x86_64</td>
-    <td class="data-table-right">64</td>
-    <td>i7-6700/Skylake<sup>*</sup></td>
-    <td class="data-table-right">3.4 GHz</td>
-    <td class="data-mean">1824</td>
-    <td class="data-stddev">(322)</td>
-    <td class="data-mean">388</td>
-    <td class="data-stddev">(2)</td>
-    <td class="data-mean">414</td>
-    <td class="data-stddev">(7)</td>
-    <td class="data-mean">1054</td>
-    <td class="data-stddev">(9)</td>
-  </tr>  <tr>
-    <td>Armv8a</td>
-    <td class="data-table-right">64</td>
-    <td>A57/Tx1/Jetson</td>
-    <td class="data-table-right">1.9 GHz</td>
-    <td class="data-mean">932</td>
-    <td class="data-stddev">(72)</td>
-    <td class="data-mean">419</td>
-    <td class="data-stddev">(6)</td>
-    <td class="data-mean">430</td>
-    <td class="data-stddev">(2)</td>
-    <td class="data-mean">1021</td>
-    <td class="data-stddev">(25)</td>
-  </tr>  <tr>
-    <td>RV64IMAC</td>
-    <td class="data-table-right">64</td>
-    <td>U54-MC/SiFive Freedom U540/Hifive</td>
-    <td class="data-table-right">1.5 GHz</td>
-    <td class="data-mean">3373</td>
-    <td class="data-stddev">(121)</td>
-    <td class="data-mean">677</td>
-    <td class="data-stddev">(20)</td>
-    <td class="data-mean">747</td>
-    <td class="data-stddev">(84)</td>
-    <td class="data-mean">4211</td>
-    <td class="data-stddev">(161)</td>
-  </tr></table>
-  </div>
-  <p class="text-light text-xs sm:text-sm mt-4">
-    <sup>*</sup> without meltdown mitigation
-  </p>
-</div>
+{% include benchmark-table.html section="Default" %}
+{% include benchmark-table.html section="MCS" %}
 
 <div class="theprose mx-auto pt-20">
 <h2 id="compil-details">Compilation Details</h2>
@@ -260,104 +94,14 @@ docker file repository</a></p>
 
 <details>
 <summary class="theprose mx-auto">See details on compiler and build commands</summary>
-<h3 class="h3-size text-dark mt-12 mb-6 max-w-4xl mx-auto">Default</h3>
-  <div class="w-full overflow-x-auto">
-  <table class="data-table">
-  <tr>
-    <th>ISA</th>
-    <th>Mode</th>
-    <th>Core/SoC/Board</th>
-    <th>Clock</th>
-    <th>Compiler</th>
-    <th>Build command</th>
-  </tr>  <tr>
-    <td>Armv7a</td>
-    <td class="data-table-right">32</td>
-    <td>A9/i.MX6/Sabre</td>
-    <td class="data-table-right">1.0 GHz</td>
-    <td>arm-linux-gnueabi-gcc GNU 10.2.1</td>
-    <td class="monospace">init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DAARCH32=TRUE -DPLATFORM=sabre</td>
-  </tr>  <tr>
-    <td>x86_64</td>
-    <td class="data-table-right">64</td>
-    <td>i7-4770/Haswell</td>
-    <td class="data-table-right">3.4 GHz</td>
-    <td>gcc GNU 10.2.1</td>
-    <td class="monospace">init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DPLATFORM=x86_64</td>
-  </tr>  <tr>
-    <td>x86_64</td>
-    <td class="data-table-right">64</td>
-    <td>i7-6700/Skylake</td>
-    <td class="data-table-right">3.4 GHz</td>
-    <td>gcc GNU 10.2.1</td>
-    <td class="monospace">init-build.sh -DKernelSkimWindow=FALSE -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DPLATFORM=x86_64</td>
-  </tr>  <tr>
-    <td>Armv8a</td>
-    <td class="data-table-right">64</td>
-    <td>A57/Tx1/Jetson</td>
-    <td class="data-table-right">1.9 GHz</td>
-    <td>aarch64-linux-gnu-gcc GNU 10.2.1</td>
-    <td class="monospace">init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DAARCH64=TRUE -DPLATFORM=tx1</td>
-  </tr>  <tr>
-    <td>RV64IMAC</td>
-    <td class="data-table-right">64</td>
-    <td>U54-MC/SiFive Freedom U540/Hifive</td>
-    <td class="data-table-right">1.5 GHz</td>
-    <td>riscv64-unknown-elf-gcc GNU 8.3.0</td>
-    <td class="monospace">init-build.sh -DFASTPATH=TRUE -DHARDWARE=FALSE -DFAULT=FALSE -DRISCV64=TRUE -DPLATFORM=hifive</td>
-  </tr></table>
-  </div>
-
-<h3 class="h3-size text-dark mt-12 mb-6 max-w-4xl mx-auto">MCS</h3>
-<div class="w-full overflow-x-auto">
-<table class="data-table">
-  <tr>
-    <th>ISA</th>
-    <th>Mode</th>
-    <th>Core/SoC/Board</th>
-    <th>Clock</th>
-    <th>Compiler</th>
-    <th>Build command</th>
-  </tr>  <tr>
-    <td>Armv7a</td>
-    <td class="data-table-right">32</td>
-    <td>A9/i.MX6/Sabre</td>
-    <td class="data-table-right">1.0 GHz</td>
-    <td>arm-linux-gnueabi-gcc GNU 10.2.1</td>
-    <td class="monospace">init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DAARCH32=TRUE -DPLATFORM=sabre -DMCS=TRUE</td>
-  </tr>  <tr>
-    <td>x86_64</td>
-    <td class="data-table-right">64</td>
-    <td>i7-4770/Haswell</td>
-    <td class="data-table-right">3.4 GHz</td>
-    <td>gcc GNU 10.2.1</td>
-    <td class="monospace">init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DPLATFORM=x86_64 -DMCS=TRUE</td>
-  </tr>  <tr>
-    <td>x86_64</td>
-    <td class="data-table-right">64</td>
-    <td>i7-6700/Skylake</td>
-    <td class="data-table-right">3.4 GHz</td>
-    <td>gcc GNU 10.2.1</td>
-    <td class="monospace">init-build.sh -DKernelSkimWindow=FALSE -DMCS=TRUE -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DPLATFORM=x86_64</td>
-  </tr>  <tr>
-    <td>Armv8a</td>
-    <td class="data-table-right">64</td>
-    <td>A57/Tx1/Jetson</td>
-    <td class="data-table-right">1.9 GHz</td>
-    <td>aarch64-linux-gnu-gcc GNU 10.2.1</td>
-    <td class="monospace">init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DAARCH64=TRUE -DPLATFORM=tx1 -DMCS=TRUE</td>
-  </tr>  <tr>
-    <td>RV64IMAC</td>
-    <td class="data-table-right">64</td>
-    <td>U54-MC/SiFive Freedom U540/Hifive</td>
-    <td class="data-table-right">1.5 GHz</td>
-    <td>riscv64-unknown-elf-gcc GNU 8.3.0</td>
-    <td class="monospace">init-build.sh -DFASTPATH=TRUE -DHARDWARE=FALSE -DFAULT=FALSE -DRISCV64=TRUE -DPLATFORM=hifive -DMCS=TRUE</td>
-  </tr></table>
-</div>
+{% include bench-comp-table.html section="Default" %}
+{% include bench-comp-table.html section="MCS" %}
 </details>
 
+{% if site.data.benchmarks.sha %}
+{% assign sha = site.data.benchmarks.sha %}
 <div class="theprose mx-auto pb-20">
 <h2>Source Code</h2>
-<p>This page was generated on 2025-04-14 for sel4bench-manifest <a href="https://github.com/seL4/sel4bench-manifest/blob/4cf8e02abda9b3f2dfd04984f33b47f3073aa3a2/default.xml">4cf8e02a</a>.</p>
+<p>This page was generated on {{ "now" | date: "%Y-%m-%d" }} for sel4bench-manifest <a href="https://github.com/seL4/sel4bench-manifest/blob/{{sha}}/default.xml">{{sha}}</a>.</p>
 </div>
+{% endif %}


### PR DESCRIPTION
sel4bench will be providing the performance results as json data, which we can then render here.

This eliminates the need for the data extraction python script to understand how the website works.
