### PR TITLE
Makefile: ignore linkedin and stackecxchange links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,9 @@ IGNORE_URLS += flaticon.com
 IGNORE_URLS += github.com.seL4.rfcs.pulls\?q
 IGNORE_URLS += rtx.com
 IGNORE_URLS += www.collinsaerospace.com
+IGNORE_URLS += www.linkedin.com/in/
 IGNORE_URLS += dl.acm.org/doi/10.1145/224056.224075
+IGNORE_URLS += softwareengineering.stackexchange.com/questions/99543
 
 sep:= /,/
 empty:=

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ IGNORE_URLS += www.collinsaerospace.com
 IGNORE_URLS += www.linkedin.com/in/
 IGNORE_URLS += dl.acm.org/doi/10.1145/224056.224075
 IGNORE_URLS += softwareengineering.stackexchange.com/questions/99543
+IGNORE_URLS += www.hrad.cz/en/prague-castle-for-visitors
 
 sep:= /,/
 empty:=


### PR DESCRIPTION
Getting 429 and 403 respectively, because they are all defending against crawlers. External link checking is becoming increasingly useless.