### PR TITLE
create cfp header with optional submit button

### DIFF
--- a/Summit/2022/cfp.html
+++ b/Summit/2022/cfp.html
@@ -4,14 +4,12 @@
 title: Call for Presentations
 pre: "The seL4 Summit 2022"
 pre_link: "./"
-sub: '
-<p>
-  The seL4 Summit gathers the seL4 community to learn, share and connect. The program committee solicits talks on a wide range of seL4-related <a href="#topics">topics</a>.
-</p>'
 layout: card
 redirect_from: /Foundation/Summit/2022/cfp.html
 ---
-
+{% include cfp-heading.html
+  about = 'The seL4 Summit gathers the seL4 community to learn, share and connect. The program committee solicits talks on a wide range of seL4-related <a href="#topics">topics</a>.'
+%}
 
 <!-- Important dates section -->
 {% include summit-important-dates.html

--- a/Summit/2023/cfp.html
+++ b/Summit/2023/cfp.html
@@ -5,14 +5,12 @@ title: Call for Presentations
 title: Call for Presentations
 pre: "The seL4 Summit 2023"
 pre_link: "./"
-sub: '
-<p>
-  The seL4 Summit gathers the seL4 community to learn, share and connect. The program committee solicits talks on a wide range of seL4-related <a href="#topics">topics</a>.
-</p>'
 layout: card
 redirect_from: /Foundation/Summit/2023/cfp.html
 ---
-
+{% include cfp-heading.html
+  about = 'The seL4 Summit gathers the seL4 community to learn, share and connect. The program committee solicits talks on a wide range of seL4-related <a href="#topics">topics</a>.'
+%}
 
 <!-- Important dates section -->
 {% include summit-important-dates.html

--- a/Summit/2024/cfp.html
+++ b/Summit/2024/cfp.html
@@ -4,13 +4,10 @@
 title: Call for Presentations
 pre: "The seL4 Summit 2024"
 pre_link: "./"
-sub: '
-<p>
-  The seL4 Summit gathers the seL4 community to learn, share and connect. The program committee solicits talks on a wide range of seL4-related <a href="#topics">topics</a>, as well as lightning talks on <a href="#deployment">seL4 deployment</a>.
-</p>'
 layout: card
 redirect_from: /Foundation/Summit/2024/cfp.html
 ---
+{% include cfp-heading.html %}
 
 
 

--- a/Summit/2025/cfp.html
+++ b/Summit/2025/cfp.html
@@ -4,18 +4,10 @@
 title: Call for Presentations
 pre: "The seL4 Summit 2025"
 pre_link: "./"
-sub: '
-<p>
-  The seL4 Summit gathers the seL4 community to learn, share and connect. The program committee solicits talks on a wide range of seL4-related <a href="#topics">topics</a>, as well as lightning talks on <a href="#deployment">seL4 deployment</a>.
-</p>
-<div class="flex justify-center items-center gap-x-5 mt-10">
-  <a href="https://form.jotform.com/250436091673861" class="button-outline px-10">Submit</a>
-</div>
-'
 layout: card
 redirect_from: /Foundation/Summit/2025/cfp.html
 ---
-
+{% include cfp-heading.html %}
 
 
 <!-- Important dates section -->

--- a/_includes/cfp-heading.html
+++ b/_includes/cfp-heading.html
@@ -1,0 +1,27 @@
+{%- comment %}
+Copyright 2025 seL4 Project a Series of LF Projects, LLC
+SPDX-License-Identifier: CC-BY-SA-4.0
+{% endcomment -%}
+
+<div class="-mt-14 sm:-mt-20 text-center text-base sm:text-lg text-light leading-6 sm:leading-7 a-underline">
+  <div class="mx-auto max-w-4xl text-center">
+    {% if include.about %}
+    <p>
+      {{include.about}}
+    </p>
+    {% else %}
+    <p>
+      The seL4 Summit gathers the seL4 community to learn, share and connect. The program committee solicits talks on a wide range of seL4-related <a href="#topics">topics</a>, as well as lightning talks on <a href="#deployment">seL4 deployment</a>.
+    </p>
+    {% endif %}
+  </div>
+  {% if include.submit-link %}
+    <div class="flex justify-center items-center gap-x-5 mt-5 mb-20">
+      {% if include.submit-link %}
+        <a href="{{include.submit-link}}" class="button-outline px-10">Submit</a>
+      {% endif %}
+    </div>
+  {% else %}
+    <div class="mb-20"></div>
+  {% endif %}
+</div>


### PR DESCRIPTION
The CFP information on the summit CFP pages usually uses the same blurb. There are slight variations in summits 2022 and 2023. This include provides options for the standard, or modified, about blurbs. It also provides an optional submit button, which leads to the submission page, when the submission portal is open.