### PR TITLE
gitlint: relax empty-body rule for this repo

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,58 @@
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Slightly more relaxed gitlint rules for this repository.
+# See seL4/sel4_tools/misc/.gitlint for the original.
+
+[general]
+# By default gitlint will ignore merge commits. Set to 'false' to disable.
+ignore-merge-commits=true
+
+# By default gitlint will ignore fixup commits. Set to 'false' to disable.
+ignore-fixup-commits=false
+
+# By default gitlint will ignore squash commits. Set to 'false' to disable.
+ignore-squash-commits=false
+
+# Main diff to general seL4 rules: we allow empty bodies in this repo
+ignore=B6
+
+# So far, gitlint uses Python's `re.match()` (match from start) by default, but
+# it will change to use the more generic `re.search()` (match anywhere) in the
+# future. With 'regex-style-search' the behaviour can be controlled. Since we
+# prefer `re.search()` anyway, the new behavior is enabled. For more details
+# see also https://jorisroovers.com/gitlint/configuration/#regex-style-search.
+regex-style-search=true
+
+
+[title-max-length]
+line-length=50
+
+[title-must-not-contain-word]
+# Comma-separated list of words that should not occur in the title. Matching is case
+# insensitive. It's fine if the keyword occurs as part of a larger word (so "WIPING"
+# will not cause a violation, but "WIP: my title" will.
+words=wip,squash,tosquash
+
+[body-max-line-length]
+line-length=72
+
+[body-min-length]
+min-length=0
+
+[ignore-by-title]
+# Ignore certain rules for commits of which the title matches a regex
+# E.g. Match commit titles that start with "Release"
+regex=^trivial(.*)
+#
+# Ignore certain rules, you can reference them by their id or by their full name
+# Use 'all' to ignore all rules
+ignore=B6
+
+[ignore-body-lines]
+# Ignore lines started with Co-authored-by, Signed-off-by
+# or lines containing a (possibly-space-indented) URL only.
+regex=(^Co-authored-by)|(^Signed-off-by)|(^\s*https?://\S+$)


### PR DESCRIPTION
A lot of the commits in this repo are routine things like "add news item", "add new member" etc, which don't really need a commit message body.