### PR TITLE
assumptions: clarify which specification

### DIFF
--- a/Verification/assumptions.html
+++ b/Verification/assumptions.html
@@ -43,7 +43,7 @@ layout: card
   <li>
     <b>Hardware:</b> we assume the hardware works correctly. In
     practice, this means the hardware is assumed not to be tampered
-    with, and working according to specification. It also means, it
+    with, and working as the formal model predicts. It also means, it
     must be run within its operating conditions.
   </li>
   <li>


### PR DESCRIPTION
The previous formulation (according to specification) was ambiguous in what specification we're talking about.